### PR TITLE
Update README commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Place the raw Plone JSON files for each course in their own directory, and place
 from ocw_data_parser import OCWParser
 
 your_parser = OCWParser("path/to/course_dir/", "path/to/output/destination/")
-# To extract the media files and master json locally inside output directory for each course directory in course_dir
+# Extract the media files and master json locally inside output directory for each course directory in course_dir
 your_parser.extract_media_locally()
-# To extract media files hosted on the Akamai cloud
+# Extract media files hosted on the Akamai cloud
 your_parser.extract_foreign_media_locally()
 
 # To upload all media to your S3 Bucket

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Place the raw Plone JSON files for each course in their own directory, and place
 from ocw_data_parser import OCWParser
 
 your_parser = OCWParser("path/to/course_dir/", "path/to/output/destination/")
-your_parser.extract_media_locally()  # To extract the media files and master json locally inside output directory for each course directory in course_dir
-your_parser.extract_foreign_media_locally()  # To extract media files hosted on the Akamai cloud
+# To extract the media files and master json locally inside output directory for each course directory in course_dir
+your_parser.extract_media_locally()
+# To extract media files hosted on the Akamai cloud
+your_parser.extract_foreign_media_locally()
 
 # To upload all media to your S3 Bucket
 # First make sure your AWS credentials are setup in your local environment

--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ pip install ocw-data-parser
 ```
 
 ## Usage
-To parse a single OCW course:
+To parse OCW courses:
+
+Place the raw Plone JSON files for each course in their own directory, and place those folders within another directory.  We will refer to this as the "course_dir."  You may place any number of courses in this directory.
+
 ```python
 from ocw_data_parser import OCWParser
 
-your_parser = OCWParser("path/to/course/", "path/to/output/destination/")
-your_parser.extract_media_locally()  # To extract the media files and master json locally inside output directory
+your_parser = OCWParser("path/to/course_dir/", "path/to/output/destination/")
+your_parser.extract_media_locally()  # To extract the media files and master json locally inside output directory for each course directory in course_dir
 your_parser.extract_foreign_media_locally()  # To extract media files hosted on the Akamai cloud
 
 # To upload all media to your S3 Bucket

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ To parse a single OCW course:
 from ocw_data_parser import OCWParser
 
 your_parser = OCWParser("path/to/course/", "path/to/output/destination/")
-your_parser.extract_master_json()  # To get the master json
-your_parser.extract_media_locally()  # To extract the media files locally inside output directory
+your_parser.extract_media_locally()  # To extract the media files and master json locally inside output directory
 your_parser.extract_foreign_media_locally()  # To extract media files hosted on the Akamai cloud
 
 # To upload all media to your S3 Bucket


### PR DESCRIPTION
This PR updates some example code in the README that was misleading. It describes parsing a "single OCW course" when in reality, the code actually crawls through sub directories of the course_dir you pass in, processing those as individual courses. The line that tells you to run "extract_master_json" is a command that doesn't exist. When "extract_media_locally" is run, a folder is created in the output directory for each course, containing a "static_files" directory along with the "master.json" file all in one command. This can be verified by running the parser in the manner I have described in the updated README.