### PR TITLE
Add optional static prefix

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -261,7 +261,9 @@ class OCWParser(object):
             log.debug("You have to compose media for course first!")
             return
 
-        path_to_containing_folder = self.destination_dir + "static_files/"
+        path_to_containing_folder = self.destination_dir + self.static_prefix \
+            if self.static_prefix else self.destination_dir + "static_files/"
+        url_path_to_media = self.static_prefix if self.static_prefix else path_to_containing_folder
         os.makedirs(path_to_containing_folder, exist_ok=True)
         for j in self.media_jsons:
             file_name = safe_get(j, "_uid") + "_" + safe_get(j, "id")
@@ -270,10 +272,7 @@ class OCWParser(object):
                 with open(path_to_containing_folder + file_name, "wb") as f:
                     data = base64.b64decode(d)
                     f.write(data)
-                if self.static_prefix:
-                    update_file_location(self.master_json, self.static_prefix + file_name, safe_get(j, "_uid"))
-                else:
-                    update_file_location(self.master_json, path_to_containing_folder + file_name, safe_get(j, "_uid"))
+                update_file_location(self.master_json, url_path_to_media + file_name, safe_get(j, "_uid"))
                 log.info("Extracted %s", file_name)
             else:
                 json_file = j["actual_file_name"]
@@ -286,17 +285,16 @@ class OCWParser(object):
             log.debug("Your course has 0 foreign media files")
             return
 
-        path_to_containing_folder = self.destination_dir + "static_files/"
+        path_to_containing_folder = self.destination_dir + self.static_prefix \
+            if self.static_prefix else self.destination_dir + "static_files/"
+        url_path_to_media = self.static_prefix if self.static_prefix else path_to_containing_folder
         os.makedirs(path_to_containing_folder, exist_ok=True)
         for media in self.large_media_links:
             file_name = media["link"].split("/")[-1]
             with open(path_to_containing_folder + file_name, "wb") as file:
                 response = get(media["link"])
                 file.write(response.content)
-            if self.static_prefix:
-                update_file_location(self.master_json, self.static_prefix + file_name)
-            else:
-                update_file_location(self.master_json, path_to_containing_folder + file_name)
+            update_file_location(self.master_json, url_path_to_media + file_name)
             log.info("Extracted %s", file_name)
         log.info("Done! extracted foreign media to %s", path_to_containing_folder)
         self.export_master_json()

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -300,6 +300,10 @@ class OCWParser(object):
         self.export_master_json()
 
     def generate_static_site(self):
+        """
+        Extract all static media locally and generate master.json, 
+        then generate static HTML for a course
+        """
         self.extract_media_locally()
         self.extract_foreign_media_locally()
         generate_html_for_course(

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -133,6 +133,8 @@ class OCWParser(object):
         new_json["short_url"] = safe_get(self.jsons[0], "id")
         new_json["image_src"] = self.course_image_s3_link
         new_json["image_description"] = self.course_image_alt_text
+        new_json["image_alternate_text"] = safe_get(self.jsons[1], "image_alternate_text")
+        new_json["image_caption_text"] = safe_get(self.jsons[1], "image_caption_text")
         tags_strings = safe_get(self.jsons[0], "subject")
         tags = list()
         for tag in tags_strings:
@@ -264,17 +266,17 @@ class OCWParser(object):
         path_to_containing_folder = self.destination_dir + "static_files/"
         os.makedirs(path_to_containing_folder, exist_ok=True)
         for j in self.media_jsons:
-            filename = safe_get(j, "_uid") + "_" + safe_get(j, "id")
+            file_name = safe_get(j, "_uid") + "_" + safe_get(j, "id")
             d = get_binary_data(j)
             if d:
-                with open(path_to_containing_folder + filename, "wb") as f:
+                with open(path_to_containing_folder + file_name, "wb") as f:
                     data = base64.b64decode(d)
                     f.write(data)
                 if self.static_prefix:
-                    update_file_location(self.master_json, self.static_prefix + filename, safe_get(j, "_uid"))
+                    update_file_location(self.master_json, self.static_prefix + file_name, safe_get(j, "_uid"))
                 else:
-                    update_file_location(self.master_json, path_to_containing_folder + filename, safe_get(j, "_uid"))
-                log.info("Extracted %s", filename)
+                    update_file_location(self.master_json, path_to_containing_folder + file_name, safe_get(j, "_uid"))
+                log.info("Extracted %s", file_name)
             else:
                 json_file = j["actual_file_name"]
                 log.error("Media file %s without either datafield key", json_file)
@@ -294,9 +296,9 @@ class OCWParser(object):
                 response = get(media["link"])
                 file.write(response.content)
             if self.static_prefix:
-                update_file_location(self.master_json, self.static_prefix + filename, safe_get(j, "_uid"))
+                update_file_location(self.master_json, self.static_prefix + file_name)
             else:
-                update_file_location(self.master_json, path_to_containing_folder + filename, safe_get(j, "_uid"))
+                update_file_location(self.master_json, path_to_containing_folder + file_name)
             log.info("Extracted %s", file_name)
         log.info("Done! extracted foreign media to %s", path_to_containing_folder)
         self.export_master_json()

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -133,8 +133,6 @@ class OCWParser(object):
         new_json["short_url"] = safe_get(self.jsons[0], "id")
         new_json["image_src"] = self.course_image_s3_link
         new_json["image_description"] = self.course_image_alt_text
-        new_json["image_alternate_text"] = safe_get(self.jsons[1], "image_alternate_text")
-        new_json["image_caption_text"] = safe_get(self.jsons[1], "image_caption_text")
         tags_strings = safe_get(self.jsons[0], "subject")
         tags = list()
         for tag in tags_strings:

--- a/ocw_data_parser/static_html_generator.py
+++ b/ocw_data_parser/static_html_generator.py
@@ -117,7 +117,7 @@ def get_course_thumbnail(mj):
             thumbnail_name = media["uid"] + "_" + thumbnail_name
             if media["file_location"].split("/")[-1] == thumbnail_name:
                 return "<div class=\"container\"><div class=\"card float-left\" style=\"max-width: 330px;\"><img class=\"card-img-top\" alt=\"%s\" src=\"%s\" title=\"%s\" />\n<div class=\"card-body\"><p class=\"card-text\">\n%s\n</p></div></div>" % \
-                       (media["alt_text"], media["file_location"], media["alt_text"], media["description"])
+                       (mj["image_alternate_text"], media["file_location"], mj["image_alternate_text"], mj["image_caption_text"])
     return ""
 
 

--- a/ocw_data_parser/static_html_generator.py
+++ b/ocw_data_parser/static_html_generator.py
@@ -117,7 +117,7 @@ def get_course_thumbnail(mj):
             thumbnail_name = media["uid"] + "_" + thumbnail_name
             if media["file_location"].split("/")[-1] == thumbnail_name:
                 return "<div class=\"container\"><div class=\"card float-left\" style=\"max-width: 330px;\"><img class=\"card-img-top\" alt=\"%s\" src=\"%s\" title=\"%s\" />\n<div class=\"card-body\"><p class=\"card-text\">\n%s\n</p></div></div>" % \
-                       (mj["image_alternate_text"], media["file_location"], mj["image_alternate_text"], mj["image_caption_text"])
+                       (media["alt_text"], media["file_location"], media["alt_text"], media["description"])
     return ""
 
 


### PR DESCRIPTION
We want to be able to use the static_html_generator code to generate html for an OCW course in a repeatable way that can be opened from anywhere.  The pages should be able to be loaded locally from a hard drive or hosted on a web server.

**What are the relevant tickets?**
There are none

**What's this PR do?**
It adds the "static_prefix" optional keyword argument to the constructor for OCWParser, which is saved in self.static_prefix.  This string is then used in extract_media_locally and extract_foreign_media_locally.  If the string has been passed in, the path passed to update_file_location in both functions is simply the static_prefix value prepended before the file name.  Otherwise "path_to_containing_folder" is used, which uses the "destination_dir" keyword argument.  The result is that you are able to output html from static_html_generator that doesn't include relative paths containing this destination directory.

**How should this be manually tested?**
Process an OCW course using source JSON as described in the readme, but also pass in a static_prefix string.  A good example would be "static_files" as this is where the script currently outputs all transformed static content.  You should be able to take the resulting HTML and place it inside any folder or on a web server, and the course image will load.  Assignment PDF's should also be downloadable, along with any other static content.