### PR TITLE
Fix course image caption and alt text, course features links

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -1,6 +1,7 @@
 import logging
 from html.parser import HTMLParser
 import os
+import copy
 import base64
 from requests import get
 import boto3
@@ -144,9 +145,16 @@ class OCWParser(object):
                                    for instructor in safe_get(self.jsons[0], "instructors")]
         new_json["language"] = safe_get(self.jsons[0], "language")
         new_json["extra_course_number"] = safe_get(self.jsons[0], "linked_course_number")
-        new_json["course_features"] = safe_get(self.jsons[0], "feature_requirements")
         new_json["course_collections"] = safe_get(self.jsons[0], "category_features")
         new_json["course_pages"] = self.compose_pages()
+        course_features = []
+        for feature_requirement in safe_get(self.jsons[0], "feature_requirements"):
+            for page in new_json["course_pages"]:
+                if page["short_url"] in feature_requirement["ocw_feature_url"]:
+                    course_feature = copy.copy(feature_requirement)
+                    course_feature["ocw_feature_url"] = './resolveuid/' + page["uid"]
+                    course_features.append(course_feature)
+        new_json["course_features"] = course_features
         new_json["course_files"] = self.compose_media()
         new_json["course_embedded_media"] = self.compose_embedded_media()
         new_json["course_foreign_files"] = self.gather_foreign_media()

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -147,16 +147,20 @@ class OCWParser(object):
         new_json["extra_course_number"] = safe_get(self.jsons[0], "linked_course_number")
         new_json["course_collections"] = safe_get(self.jsons[0], "category_features")
         new_json["course_pages"] = self.compose_pages()
-        course_features = []
+        course_features = {}
         feature_requirements = safe_get(self.jsons[0], "feature_requirements")
         if feature_requirements:
             for feature_requirement in feature_requirements:
                 for page in new_json["course_pages"]:
-                    if page["short_url"] in feature_requirement["ocw_feature_url"]:
-                        course_feature = copy.copy(feature_requirement)
-                        course_feature["ocw_feature_url"] = './resolveuid/' + page["uid"]
-                        course_features.append(course_feature)
-        new_json["course_features"] = course_features
+                    ocw_feature_url = safe_get(feature_requirement, "ocw_feature_url")
+                    if (ocw_feature_url):
+                        ocw_feature_url_parts = ocw_feature_url.split("/")
+                        ocw_feature_short_url = ocw_feature_url_parts[-2] + "/" + ocw_feature_url_parts[-1]
+                        if page["short_url"] in ocw_feature_short_url and 'index.htm' not in page["short_url"]:
+                            course_feature = copy.copy(feature_requirement)
+                            course_feature["ocw_feature_url"] = './resolveuid/' + page["uid"]
+                            course_features[page["uid"]] = course_feature
+        new_json["course_features"] = list(course_features.values())
         new_json["course_files"] = self.compose_media()
         new_json["course_embedded_media"] = self.compose_embedded_media()
         new_json["course_foreign_files"] = self.gather_foreign_media()

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -148,12 +148,14 @@ class OCWParser(object):
         new_json["course_collections"] = safe_get(self.jsons[0], "category_features")
         new_json["course_pages"] = self.compose_pages()
         course_features = []
-        for feature_requirement in safe_get(self.jsons[0], "feature_requirements"):
-            for page in new_json["course_pages"]:
-                if page["short_url"] in feature_requirement["ocw_feature_url"]:
-                    course_feature = copy.copy(feature_requirement)
-                    course_feature["ocw_feature_url"] = './resolveuid/' + page["uid"]
-                    course_features.append(course_feature)
+        feature_requirements = safe_get(self.jsons[0], "feature_requirements")
+        if feature_requirements:
+            for feature_requirement in feature_requirements:
+                for page in new_json["course_pages"]:
+                    if page["short_url"] in feature_requirement["ocw_feature_url"]:
+                        course_feature = copy.copy(feature_requirement)
+                        course_feature["ocw_feature_url"] = './resolveuid/' + page["uid"]
+                        course_features.append(course_feature)
         new_json["course_features"] = course_features
         new_json["course_files"] = self.compose_media()
         new_json["course_embedded_media"] = self.compose_embedded_media()

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -155,7 +155,9 @@ class OCWParser(object):
                     ocw_feature_url = safe_get(feature_requirement, "ocw_feature_url")
                     if (ocw_feature_url):
                         ocw_feature_url_parts = ocw_feature_url.split("/")
-                        ocw_feature_short_url = ocw_feature_url_parts[-2] + "/" + ocw_feature_url_parts[-1]
+                        ocw_feature_short_url = ocw_feature_url 
+                        if len(ocw_feature_url_parts) > 1:
+                            ocw_feature_short_url = ocw_feature_url_parts[-2] + "/" + ocw_feature_url_parts[-1]
                         if page["short_url"] in ocw_feature_short_url and 'index.htm' not in page["short_url"]:
                             course_feature = copy.copy(feature_requirement)
                             course_feature["ocw_feature_url"] = './resolveuid/' + page["uid"]

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -133,6 +133,8 @@ class OCWParser(object):
         new_json["short_url"] = safe_get(self.jsons[0], "id")
         new_json["image_src"] = self.course_image_s3_link
         new_json["image_description"] = self.course_image_alt_text
+        new_json["image_alternate_text"] = safe_get(self.jsons[1], "image_alternate_text")
+        new_json["image_caption_text"] = safe_get(self.jsons[1], "image_caption_text")
         tags_strings = safe_get(self.jsons[0], "subject")
         tags = list()
         for tag in tags_strings:

--- a/ocw_data_parser/static_html_generator.py
+++ b/ocw_data_parser/static_html_generator.py
@@ -1,6 +1,6 @@
 import logging
 
-from .utils import is_json, get_correct_path, load_json_file
+from .utils import is_json, get_correct_path, get_page_from_url, load_json_file
 
 log = logging.getLogger(__name__)
 

--- a/ocw_data_parser/static_html_generator.py
+++ b/ocw_data_parser/static_html_generator.py
@@ -1,6 +1,6 @@
 import logging
 
-from .utils import is_json, get_correct_path, load_json_file
+from .utils import is_json, get_correct_path, get_page_from_url, load_json_file
 
 
 log = logging.getLogger(__name__)
@@ -139,7 +139,8 @@ def get_course_features(mj):
     course_features = "<h4>Course Features</h4>\n<ul>%s</ul>\n"
     features = ""
     for entry in mj["course_features"]:
-        features += "<li><a href=\"%s\">%s</a></li>\n" % (entry["ocw_feature_url"].replace('/index.htm', '.html'), entry["ocw_feature"])
+        url = get_page_from_url(entry["ocw_feature_url"].replace('/index.htm', '')) + '.html'
+        features += "<li><a href=\"%s\">%s</a></li>\n" % (url, entry["ocw_feature"])
     
     return course_features % features
 

--- a/ocw_data_parser/static_html_generator.py
+++ b/ocw_data_parser/static_html_generator.py
@@ -1,6 +1,6 @@
 import logging
 
-from .utils import is_json, get_correct_path, get_page_from_url, load_json_file
+from .utils import is_json, get_correct_path, load_json_file
 
 log = logging.getLogger(__name__)
 

--- a/ocw_data_parser/static_html_generator.py
+++ b/ocw_data_parser/static_html_generator.py
@@ -117,7 +117,7 @@ def get_course_thumbnail(mj):
             thumbnail_name = media["uid"] + "_" + thumbnail_name
             if media["file_location"].split("/")[-1] == thumbnail_name:
                 return "<div class=\"container\"><div class=\"card float-left\" style=\"max-width: 330px;\"><img class=\"card-img-top\" alt=\"%s\" src=\"%s\" title=\"%s\" />\n<div class=\"card-body\"><p class=\"card-text\">\n%s\n</p></div></div>" % \
-                       (media["alt_text"], media["file_location"], media["alt_text"], media["description"])
+                       (mj["image_alternate_text"], media["file_location"], mj["image_alternate_text"], mj["image_caption_text"])
     return ""
 
 

--- a/ocw_data_parser/static_html_generator.py
+++ b/ocw_data_parser/static_html_generator.py
@@ -1,7 +1,6 @@
 import logging
 
-from .utils import is_json, get_correct_path, get_page_from_url, load_json_file
-
+from .utils import is_json, get_correct_path, load_json_file
 
 log = logging.getLogger(__name__)
 
@@ -138,10 +137,9 @@ def get_course_info(mj):
 def get_course_features(mj):
     course_features = "<h4>Course Features</h4>\n<ul>%s</ul>\n"
     features = ""
-    for entry in mj["course_features"]:
-        url = get_page_from_url(entry["ocw_feature_url"].replace('/index.htm', '')) + '.html'
-        features += "<li><a href=\"%s\">%s</a></li>\n" % (url, entry["ocw_feature"])
-    
+    if mj["course_features"]:
+        for entry in mj["course_features"]:
+            features += fix_links("<li><a href=\"%s\">%s</a></li>\n" % (entry["ocw_feature_url"], entry["ocw_feature"]), mj)
     return course_features % features
 
 

--- a/ocw_data_parser/static_html_generator.py
+++ b/ocw_data_parser/static_html_generator.py
@@ -139,7 +139,7 @@ def get_course_features(mj):
     course_features = "<h4>Course Features</h4>\n<ul>%s</ul>\n"
     features = ""
     for entry in mj["course_features"]:
-        features += "<li><a href=\"%s\">%s</a></li>\n" % (entry["ocw_feature_url"], entry["ocw_feature"])
+        features += "<li><a href=\"%s\">%s</a></li>\n" % (entry["ocw_feature_url"].replace('/index.htm', '.html'), entry["ocw_feature"])
     
     return course_features % features
 

--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 
 log = logging.getLogger(__name__)
 

--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -38,12 +38,6 @@ def get_correct_path(directory):
         return ""
     return directory if directory[-1] == "/" else directory + "/"
 
-def get_page_from_url(url):
-    try:
-        return os.path.split(url)[1]
-    except ValueError:
-        log.exception("Failed to parse URL %s", url)
-
 def load_json_file(path):
     with open(path, 'r') as f:
         try:

--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -1,6 +1,6 @@
 import json
 import logging
-
+import os
 
 log = logging.getLogger(__name__)
 
@@ -38,6 +38,11 @@ def get_correct_path(directory):
         return ""
     return directory if directory[-1] == "/" else directory + "/"
 
+def get_page_from_url(url):
+    try:
+        return os.path.split(url)[1]
+    except ValueError:
+        log.exception("Failed to parse URL %s", url)
 
 def load_json_file(path):
     with open(path, 'r') as f:


### PR DESCRIPTION
The course image caption and alt text are coming from what looks to be the wrong property of the source JSON.  Course features links are absolute in the source JSON, which does not work for viewing the site locally or hosting it on any given web server.

#### What are the relevant tickets?

https://github.com/mitodl/ocw-data-parser/pull/14 should be merged before this, as it contains code that allows you to pass in a static prefix and fix viewing the site locally from anywhere besides the folder you ran the script from.  Without it, the course image itself won't load and links to other static content such as PDF's will not work.

#### What's this PR do?

An analysis of current OCW pages and the source JSON reveals that a better place to get the course image caption & alt text is from the image_caption_text and image_alternate_text properties on 2.json, which seems to always a JSON export representing the course home page.  "Course features" URLs in the source JSON are fully qualified links to ocw.mit.edu.  The code has been changed to rewrite these to "resolveuid" links to the appropriate section, matching on "short_url."

#### How should this be manually tested?

Process an OCW course as detailed in the readme and the course image alt text and caption should match the course on ocw.mit.edu.  Course features links should point to the appropriate page.