### PR TITLE
Write raw HTML for course pages

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -222,6 +222,7 @@ class OCWParser(object):
         def _compose_media_dict(j):
             return {
                 "uid": safe_get(j, "_uid"),
+                "id": safe_get(j, "id"),
                 "parent_uid": safe_get(j, "parent_uid"),
                 "title": safe_get(j, "title"),
                 "caption": safe_get(j, "caption"),

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -67,11 +67,16 @@ def test_upload_all_data_to_s3(ocw_parser_s3, s3_bucket):
     Use moto (mock boto) to test s3 uploading
     """
     ocw_parser_s3.upload_all_media_to_s3(upload_master_json=True)
-    course_image_key = None
-    for bucket_item in s3_bucket.objects.filter(Prefix=ocw_parser_s3.s3_target_folder):
-        if bucket_item.key in ocw_parser_s3.course_image_s3_link:
-            course_image_key = bucket_item.key
-    assert course_image_key is not None
+    master_json = ocw_parser_s3.get_master_json()
+    for p in master_json["course_pages"]:
+        if p["text"]:
+            for bucket_item in s3_bucket.objects.filter(Prefix=ocw_parser_s3.s3_target_folder):
+                if bucket_item.key in p["file_location"]:
+                    assert bucket_item.key == ocw_parser_s3.s3_target_folder + p["uid"] + "_" + p["short_url"] + ".html"
+    for f in master_json["course_files"]:
+        for bucket_item in s3_bucket.objects.filter(Prefix=ocw_parser_s3.s3_target_folder):
+            if bucket_item.key in f["file_location"]:
+                assert bucket_item.key == ocw_parser_s3.s3_target_folder + f["uid"] + "_" + f["id"]
 
 def test_upload_course_image(ocw_parser_s3, s3_bucket):
     """

--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -6,6 +6,9 @@ log = logging.getLogger(__name__)
 
 def update_file_location(master_json, new_file_location, obj_uid=""):
     if obj_uid:
+        for p in master_json["course_pages"]:
+            if p["uid"] == obj_uid:
+                p["file_location"] = new_file_location
         for j in master_json["course_files"]:
             if j["uid"] == obj_uid:
                 j["file_location"] = new_file_location

--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -78,3 +78,11 @@ def find_all_values_for_key(jsons, key="_content_type"):
         if value in result:
             result.remove(value)
     return result
+
+def htmlify(page):
+    safe_text = safe_get(page, "text")
+    if safe_text:
+        file_name = safe_get(page, "uid") + "_" + safe_get(page, "short_url") + ".html"
+        html = "<html><head></head><body>" + safe_text + "</body></html>"
+        return file_name, html
+    return None, None

--- a/ocw_data_parser/utils_test.py
+++ b/ocw_data_parser/utils_test.py
@@ -1,7 +1,7 @@
 import os
 import json
 import pytest
-from ocw_data_parser.utils import update_file_location, get_binary_data, is_json, get_correct_path, load_json_file, print_error, print_success, safe_get, find_all_values_for_key
+from ocw_data_parser.utils import update_file_location, get_binary_data, is_json, get_correct_path, load_json_file, print_error, print_success, safe_get, find_all_values_for_key, htmlify
 
 
 def test_update_local_file_location(ocw_parser):
@@ -79,3 +79,18 @@ def test_safe_get_invalid_value(ocw_parser):
         "actual_file_name": "test"
     }
     assert safe_get(test_dict, "value_three", print_error_message=True) is None
+
+def test_htmlify(ocw_parser):
+    """
+    Test that calling htmlify on a page returns some html and a filename
+    """
+    master_json = ocw_parser.get_master_json()
+    course_pages = safe_get(master_json, "course_pages")
+    test_page = course_pages[0]
+    filename, html = htmlify(test_page)
+    assert filename == test_page["uid"] + "_" + test_page["short_url"] + ".html"
+    assert "<html>" in html
+    assert "</html>" in html
+    assert "<body>" in html
+    assert "</body>" in html
+    assert test_page["text"] in html


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None at the moment

#### What's this PR do?
Add code in both `extract_media_locally` and `upload_all_media_to_s3` to write raw html files for each `course_page` along with the other static files, as well as a `file_location` key on the `course_pages` objects and code in `update_file_location` to also scan `course_pages` and update html file locations.

#### How should this be manually tested?
Instantiate a parser and run `extract_media_locally` and `upload_all_media_to_s3` (after configuring it to point to a bucket) and .html files should be written into the `static_files` directory.  Each object in the `course_pages` array should also have a `file_location` key with a file system path if run through `extract_media_locally` or an s3 link if run through `upload_all_media_to_s3`.  All tests should also pass from running `python3 -m pytest`.