### PR TITLE
remove missing thumbnail error

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -116,8 +116,6 @@ class OCWParser(object):
             # CourseHomeSection for courses and SRHomePage is for resources
             if classname in ["CourseHomeSection", "SRHomePage"]:
                 self.course_image_uid = j.get("chp_image")
-        if not self.course_image_uid:
-            log.error("Missing course thumbnail image")
         # Generate master JSON
         new_json = dict()
         new_json["uid"] = safe_get(self.jsons[0], "_uid")


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2258

#### What's this PR do?
Many older OCW runs do not have a thumbnail so this error is produced too often to be useful when course run are reindexed.

https://github.com/mitodl/open-discussions/pull/2628 adds a fix for course thumbnails being missing after indexing

#### How should this be manually tested?
NA

