### PR TITLE
upload master json in image only s3 upload

### DIFF
--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -86,6 +86,11 @@ def test_upload_all_data_to_s3(ocw_parser_s3, s3_bucket):
             assert master_json["thumbnail_image_src"] == s3_upload_base() + f["uid"] + "_" + f["id"]
             assert master_json["thumbnail_image_description"] == f["description"]
 
+    for bucket_item in s3_bucket.objects.filter(Prefix=ocw_parser_s3.s3_target_folder):
+        if bucket_item.key == ocw_parser_s3.s3_target_folder + master_json["uid"] + "_master.json":
+            master_json_key = bucket_item.key
+    assert master_json_key is not None
+    
     assert master_json["image_src"] is not None
     assert master_json["thumbnail_image_src"] is not None
 
@@ -96,12 +101,16 @@ def test_upload_course_image(ocw_parser_s3, s3_bucket):
     """
     ocw_parser_s3.upload_course_image()
     course_image_key = None
+    master_json = ocw_parser_s3.get_master_json()
+
     for bucket_item in s3_bucket.objects.filter(Prefix=ocw_parser_s3.s3_target_folder):
         if bucket_item.key in ocw_parser_s3.course_image_s3_link:
             course_image_key = bucket_item.key
+        elif bucket_item.key == ocw_parser_s3.s3_target_folder + master_json["uid"] + "_master.json":
+            master_json_key = bucket_item.key
+    
     assert course_image_key is not None
-
-    master_json = ocw_parser_s3.get_master_json()
+    assert master_json_key is not None
 
     assert ocw_parser_s3.master_json["image_src"] is not None
     assert ocw_parser_s3.master_json["thumbnail_image_src"] is not None


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/hMBi6zoF/236-upload-masterjson-when-ocwuploadimageonly-true

#### What's this PR do?
This PR updates the code to update the master json file when only the image is synched to s3 for a course

#### How should this be manually tested?
In open-discussions replace the line for ocw-data-parser in your requirements.in file with
`git+git://github.com/mitodl/ocw-data-parser.git@ab/image-only-upload-master-json#egg=ocw-data-parser`

Run `pip-compile requirements.in` and `docker-compose build`.

Set `OCW_UPLOAD_IMAGE_ONLY=true` in your .env file
From the open-discussions shell run:
```
from course_catalog.api import *
sync_ocw_courses(course_prefixes=["PROD/RES/RES.2-005/Spring_2015/res-2-005-girls-who-build-make-your-own-wearables-workshop-spring-2015/"],blacklist=[], force_overwrite=True, upload_to_s3=True)
```

Verify that the master.json file is updated in the res-2-005-girls-who-build-make-your-own-wearables-workshop-spring-2015 folder in the open-learning-course-data-ci bucket