### PR TITLE
is_image_gallery

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -202,6 +202,7 @@ class OCWParser(object):
                 "short_url": safe_get(j, "id"),
                 "description": safe_get(j, "description"),
                 "type": safe_get(j, "_type"),
+                "is_image_gallery": safe_get(j, "is_image_gallery"),
                 "is_media_gallery": safe_get(j, "is_media_gallery"),
                 "file_location": safe_get(j, "_uid") + "_" + safe_get(j, "id") + ".html"
             }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hugo-course-publisher/issues/134

#### What's this PR do?
This PR adds the `is_image_gallery` flag to `course_pages` objects in the master json.

#### How should this be manually tested?
Convert a course that has a page with an image gallery, such as [this](https://ocw.mit.edu/courses/earth-atmospheric-and-planetary-sciences/12-001-introduction-to-geology-fall-2013/field-trip/) one.  Verify that the corresponding `course_pages` object in the resulting `master.json` file contains the `is_image_gallery` flag and that it's set properly for pages that are supposed to have one.
