### PR TITLE
Add order_index

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -103,11 +103,7 @@ class OCWParser(object):
                     # Add the json file name (used for error reporting)
                     loaded_json["actual_file_name"] = str(json_index) + ".json"
                     # The only representation we have of ordering is the file name
-                    try:
-                        order_index = int(json_index)
-                    except ValueError:
-                        order_index = None
-                    loaded_json["order_index"] = order_index
+                    loaded_json["order_index"] = int(json_index)
                     loaded_jsons.append(loaded_json)
                 else:
                     log.error("Failed to load %s", file_path)

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -102,6 +102,12 @@ class OCWParser(object):
                 if loaded_json:
                     # Add the json file name (used for error reporting)
                     loaded_json["actual_file_name"] = str(json_index) + ".json"
+                    # The only representation we have of ordering is the file name
+                    try:
+                        order_index = int(json_index)
+                    except:
+                        order_index = None
+                    loaded_json["order_index"] = order_index
                     loaded_jsons.append(loaded_json)
                 else:
                     log.error("Failed to load %s", file_path)
@@ -194,7 +200,7 @@ class OCWParser(object):
             if url_data:
                 url_data = url_data.split("ocw.mit.edu")[1]
             page_dict = {
-                "order_index": safe_get(j, "actual_file_name").replace(".json", ""),
+                "order_index": safe_get(j, "order_index"),
                 "uid": safe_get(j, "_uid"),
                 "parent_uid": safe_get(j, "parent_uid"),
                 "title": safe_get(j, "title"),
@@ -227,7 +233,7 @@ class OCWParser(object):
     def compose_media(self):
         def _compose_media_dict(j):
             return {
-                "order_index": safe_get(j, "actual_file_name").replace(".json", ""),
+                "order_index": safe_get(j, "order_index"),
                 "uid": safe_get(j, "_uid"),
                 "id": safe_get(j, "id"),
                 "parent_uid": safe_get(j, "parent_uid"),
@@ -256,7 +262,7 @@ class OCWParser(object):
         for j in self.jsons:
             if j and "inline_embed_id" in j and j["inline_embed_id"]:
                 temp = {
-                    "order_index": safe_get(j, "actual_file_name").replace(".json", ""),
+                    "order_index": safe_get(j, "order_index"),
                     "title": j["title"],
                     "uid": j["_uid"],
                     "parent_uid": j["parent_uid"],

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -194,6 +194,7 @@ class OCWParser(object):
             if url_data:
                 url_data = url_data.split("ocw.mit.edu")[1]
             page_dict = {
+                "order_index": safe_get(j, "actual_file_name").replace(".json", ""),
                 "uid": safe_get(j, "_uid"),
                 "parent_uid": safe_get(j, "parent_uid"),
                 "title": safe_get(j, "title"),
@@ -226,6 +227,7 @@ class OCWParser(object):
     def compose_media(self):
         def _compose_media_dict(j):
             return {
+                "order_index": safe_get(j, "actual_file_name").replace(".json", ""),
                 "uid": safe_get(j, "_uid"),
                 "id": safe_get(j, "id"),
                 "parent_uid": safe_get(j, "parent_uid"),
@@ -254,6 +256,7 @@ class OCWParser(object):
         for j in self.jsons:
             if j and "inline_embed_id" in j and j["inline_embed_id"]:
                 temp = {
+                    "order_index": safe_get(j, "actual_file_name").replace(".json", ""),
                     "title": j["title"],
                     "uid": j["_uid"],
                     "parent_uid": j["parent_uid"],

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -105,7 +105,7 @@ class OCWParser(object):
                     # The only representation we have of ordering is the file name
                     try:
                         order_index = int(json_index)
-                    except:
+                    except ValueError:
                         order_index = None
                     loaded_json["order_index"] = order_index
                     loaded_jsons.append(loaded_json)

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -38,17 +38,10 @@ def test_parser_invalid_file(ocw_parser):
     """
     with TemporaryDirectory() as destination_dir:
         with open(os.path.join(constants.COURSE_DIR, "jsons/test.json"), "w") as f:
-            found = False
-            try:
-                parser = OCWParser(course_dir=constants.COURSE_DIR,
-                                destination_dir=destination_dir,
-                                static_prefix=constants.STATIC_PREFIX)
-                for json in parser.jsons:
-                    if not json.order_index:
-                        found = True
-                assert found == True
-            except:
-                found = False
+            with pytest.raises(ValueError):
+                OCWParser(course_dir=constants.COURSE_DIR,
+                            destination_dir=destination_dir,
+                            static_prefix=constants.STATIC_PREFIX)
             os.remove(os.path.join(constants.COURSE_DIR, "jsons/test.json"))
 
 def test_generate_master_json_none_source(ocw_parser):

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -32,6 +32,25 @@ def test_parser_loaded_jsons(ocw_parser):
     """
     assert OCWParser(loaded_jsons=ocw_parser.jsons), "instantiating parser with preloaded jsons failed"
 
+def test_parser_invalid_file(ocw_parser):
+    """
+    Test instantiating a parser with an improperly named json file in the source directory
+    """
+    with TemporaryDirectory() as destination_dir:
+        with open(os.path.join(constants.COURSE_DIR, "jsons/test.json"), "w") as f:
+            found = False
+            try:
+                parser = OCWParser(course_dir=constants.COURSE_DIR,
+                                destination_dir=destination_dir,
+                                static_prefix=constants.STATIC_PREFIX)
+                for json in parser.jsons:
+                    if not json.order_index:
+                        found = True
+                assert found == True
+            except:
+                found = False
+            os.remove(os.path.join(constants.COURSE_DIR, "jsons/test.json"))
+
 def test_generate_master_json_none_source(ocw_parser):
     """
     Make sure that running generate_master_json doesn't throw an error after nulling 


### PR DESCRIPTION
This PR adds the `order_index` property to pages and media in a course based on the numbered filename of the Plone JSON export.  Related to this issue: https://github.com/mitodl/hugo-course-publisher/issues/143