### PR TITLE
fix course downloader

### DIFF
--- a/ocw_data_parser/course_downloader.py
+++ b/ocw_data_parser/course_downloader.py
@@ -25,6 +25,7 @@ class OCWDownloader(object):
 
     def download_courses(self):
         courses = None
+        downloaded_courses = []
         with open(self.courses_json) as f:
             courses = json.load(f)["courses"]
         if not os.path.exists(self.destination_dir):
@@ -54,9 +55,10 @@ class OCWDownloader(object):
                             with open(dest_filename, "wb+") as f:
                                 s3_client.download_fileobj(
                                     self.s3_bucket_name, obj["Key"], f)
+                                if course_id not in downloaded_courses:
+                                    downloaded_courses.append(course_id)
         
         # make sure everything downloaded right
-        downloaded_courses = os.listdir(self.destination_dir)
         for course_id in courses:
             if course_id not in downloaded_courses:
                 print("{} was not found in the s3 bucket {}".format(course_id, self.s3_bucket_name))

--- a/ocw_data_parser/course_downloader.py
+++ b/ocw_data_parser/course_downloader.py
@@ -54,10 +54,9 @@ class OCWDownloader(object):
                             with open(dest_filename, "wb+") as f:
                                 s3_client.download_fileobj(
                                     self.s3_bucket_name, obj["Key"], f)
-                        courses.pop(courses.index(course_id))
         
-        # if there are still courses in the list, that means they weren't found on s3
-        if len(courses) > 0:
-            print("The following courses were not found in the s3 bucket {}:".format(self.s3_bucket_name))
-            for course_id in courses:
-                print(" - {}".format(course_id))
+        # make sure everything downloaded right
+        downloaded_courses = os.listdir(self.destination_dir)
+        for course_id in courses:
+            if course_id not in downloaded_courses:
+                print("{} was not found in the s3 bucket {}".format(course_id, self.s3_bucket_name))

--- a/ocw_data_parser/course_downloader_test.py
+++ b/ocw_data_parser/course_downloader_test.py
@@ -18,14 +18,14 @@ def test_download_courses(ocw_downloader):
     end up where they're supposed to
     """
     ocw_downloader.download_courses()
-    for root, dirs, files in os.walk(ocw_downloader.destination_dir):
+    for root, dirs, files in os.walk(constants.COURSE_DIR):
         if len(dirs) == 0 and len(files) > 0:
             path, folder = os.path.split(root)
-            if folder == "0":
+            if folder == "jsons":
                 path, course = os.path.split(path)
                 for json_file in files:
-                    test_data_path = os.path.join(constants.COURSE_DIR, course, "jsons", json_file)
-                    downloaded_path = os.path.join(path, course, "0", json_file)
+                    test_data_path = os.path.join(path, course, "jsons", json_file)
+                    downloaded_path = os.path.join(ocw_downloader.destination_dir, course, "0", json_file)
                     assert filecmp.cmp(test_data_path, downloaded_path)
 
 def test_download_courses_no_destination_dir(ocw_downloader):

--- a/ocw_data_parser/course_downloader_test.py
+++ b/ocw_data_parser/course_downloader_test.py
@@ -38,6 +38,15 @@ def test_download_courses_no_destination_dir(ocw_downloader):
         ocw_downloader.download_courses()
         mock.assert_any_call(ocw_downloader.destination_dir)
 
+def test_download_courses_missing_course(ocw_downloader, capfd):
+    """
+    Download the courses, but add a course to courses.json that doesn't exist first
+    """
+    ocw_downloader.courses_json = "ocw_data_parser/test_json/courses_missing.json"
+    ocw_downloader.download_courses()
+    out, err = capfd.readouterr()
+    assert "missing was not found in the s3 bucket testing" in out
+
 def test_download_courses_overwrite(ocw_downloader):
     """
     Download the courses, then mark overwrite as true and do it again and 

--- a/ocw_data_parser/test_json/courses_missing.json
+++ b/ocw_data_parser/test_json/courses_missing.json
@@ -1,0 +1,7 @@
+{
+    "courses": [
+        "course-1",
+        "course-2",
+        "missing"
+    ]
+}


### PR DESCRIPTION
The `course_downloader` was unfortunately committed and merged in a broken state.  I wrote the test for this condition backwards by accident, looping over the destination folder for comparison rather than the source folder.  This PR corrects the test and uses a different method to ensure that all the courses requested for download existed in the bucket.