### PR TITLE
fix file_location in master json uploaded by upload_course_image

### DIFF
--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -160,6 +160,8 @@ def test_upload_course_image(ocw_parser_s3, s3_bucket):
             assert master_json["thumbnail_image_src"] == s3_upload_base(
             ) + f["uid"] + "_" + f["id"]
             assert master_json["thumbnail_image_description"] == f["description"]
+        else:
+            assert f["file_location"]
 
 
 def test_upload_course_image_no_s3_bucket_name(ocw_parser_s3, caplog):

--- a/ocw_data_parser/utils_test.py
+++ b/ocw_data_parser/utils_test.py
@@ -80,7 +80,7 @@ def test_safe_get_invalid_value(ocw_parser):
         "value_two": "2",
         "actual_file_name": "test"
     }
-    assert safe_get(test_dict, "value_three", print_error_message=True) is None
+    assert safe_get(test_dict, "value_three") is None
 
 def test_htmlify(ocw_parser):
     """


### PR DESCRIPTION
Closes https://github.com/mitodl/ocw-data-parser/issues/47

This PR adds a function level override to `update_s3_content` called `upload` that can override the class level `upload_to_s3` flag in the case you want to populate master json with the s3 links to all the content but not actually upload any of it.  `upload_course_image` now does this before actually uploading the course image so when it saves master json, it contains the proper `file_location` for other files.

To test this, grab the raw json for any course either manually or using `course_downloader` and then load it into an `OCWParser` instance.  Configure s3 uploading using the RC keys from heroku and the `open-learning-course-data-rc` bucket.  Run `upload_course_image` and ensure that the master.json file uploaded to that course does not have missing `file_location` properties.