### PR TITLE
Add open_learning_library_related

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -191,28 +191,20 @@ class OCWParser(object):
                             course_feature["ocw_feature_url"] = './resolveuid/' + page["uid"]
                             course_features[page["uid"]] = course_feature
         new_json["course_features"] = list(course_features.values())
-        courselist_features = []
-        courselist_features_raw = safe_get(self.jsons[0], "courselist_features")
-        if course_features:
-            for courselist_feature_raw in courselist_features_raw:
-                ocw_feature = courselist_feature_raw["ocw_feature"]
-                courselist_feature = {}
-                courselist_feature["ocw_feature"] = ocw_feature
-                if ocw_feature == "Open Learning Library":
-                    raw_url = courselist_feature_raw["ocw_feature_url"]
-                    texts_and_urls = raw_url.split(",")
-                    for text_and_url in texts_and_urls:
-                        text, url = text_and_url.strip().split("::")
-                        courselist_feature["ocw_subfeature"] = text
-                        courselist_feature["ocw_feature_url"] = url
-                        courselist_features.append(courselist_feature)
-                else:
-                    for attr in courselist_feature_raw:
-                        value = courselist_feature_raw[attr]
-                        if value:
-                            courselist_feature[attr] = value
-                    courselist_features.append(courselist_feature)
-        new_json["courselist_features"] = courselist_features
+        open_learning_library_related = []
+        courselist_features = safe_get(self.jsons[0], "courselist_features")
+        if courselist_features:
+            for courselist_feature in courselist_features:
+                if courselist_feature["ocw_feature"] == "Open Learning Library":
+                    raw_url = courselist_feature["ocw_feature_url"]
+                    courses_and_links = raw_url.split(",")
+                    for course_and_link in courses_and_links:
+                        related_course = {}
+                        course, url = course_and_link.strip().split("::")
+                        related_course["course"] = course
+                        related_course["url"] = url
+                        open_learning_library_related.append(related_course)
+        new_json["open_learning_library_related"] = open_learning_library_related
         new_json["course_files"] = self.compose_media()
         new_json["course_embedded_media"] = self.compose_embedded_media()
         new_json["course_foreign_files"] = self.gather_foreign_media()

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -191,6 +191,31 @@ class OCWParser(object):
                             course_feature["ocw_feature_url"] = './resolveuid/' + page["uid"]
                             course_features[page["uid"]] = course_feature
         new_json["course_features"] = list(course_features.values())
+        courselist_features = []
+        courselist_features_raw = safe_get(self.jsons[0], "courselist_features")
+        if course_features:
+            for courselist_feature_raw in courselist_features_raw:
+                ocw_feature = course_feature["ocw_feature"]
+                courselist_feature = {}
+                courselist_feature["ocw_feature"] = ocw_feature
+                if ocw_feature == "MITx":
+                    courselist_feature["ocw_subfeature"] = courselist_feature_raw["ocw_subfeature"]
+                elif ocw_feature == "CrossLinks":
+                    courselist_feature["ocw_feature_url"] = courselist_feature_raw["ocw_feature_url"]
+                elif ocw_feature == "Open Learning Library":
+                    raw_url = courselist_feature["ocw_feature_url"]
+                    texts_and_urls = raw_url.split(", ")
+                    for text_and_url in texts_and_urls:
+                        text, url = text_and_url.split("::")
+                        courselist_feature["ocw_subfeature"] = text
+                        courselist_feature["ocw_feature_url"] = url
+                else:
+                    for attr in courselist_feature_raw:
+                        value = courselist_feature_raw[attr]
+                        if value:
+                            courselist_feature[attr] = value
+                courselist_features.append(courselist_feature)
+        new_json["courselist_features"] = courselist_features
         new_json["course_files"] = self.compose_media()
         new_json["course_embedded_media"] = self.compose_embedded_media()
         new_json["course_foreign_files"] = self.gather_foreign_media()

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -192,7 +192,7 @@ class OCWParser(object):
                             course_features[page["uid"]] = course_feature
         new_json["course_features"] = list(course_features.values())
         open_learning_library_related = []
-        courselist_features = safe_get(self.jsons[0], "courselist_features")
+        courselist_features = self.jsons[0].get("courselist_features")
         if courselist_features:
             for courselist_feature in courselist_features:
                 if courselist_feature["ocw_feature"] == "Open Learning Library":

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -195,26 +195,23 @@ class OCWParser(object):
         courselist_features_raw = safe_get(self.jsons[0], "courselist_features")
         if course_features:
             for courselist_feature_raw in courselist_features_raw:
-                ocw_feature = course_feature["ocw_feature"]
+                ocw_feature = courselist_feature_raw["ocw_feature"]
                 courselist_feature = {}
                 courselist_feature["ocw_feature"] = ocw_feature
-                if ocw_feature == "MITx":
-                    courselist_feature["ocw_subfeature"] = courselist_feature_raw["ocw_subfeature"]
-                elif ocw_feature == "CrossLinks":
-                    courselist_feature["ocw_feature_url"] = courselist_feature_raw["ocw_feature_url"]
-                elif ocw_feature == "Open Learning Library":
-                    raw_url = courselist_feature["ocw_feature_url"]
-                    texts_and_urls = raw_url.split(", ")
+                if ocw_feature == "Open Learning Library":
+                    raw_url = courselist_feature_raw["ocw_feature_url"]
+                    texts_and_urls = raw_url.split(",")
                     for text_and_url in texts_and_urls:
-                        text, url = text_and_url.split("::")
+                        text, url = text_and_url.strip().split("::")
                         courselist_feature["ocw_subfeature"] = text
                         courselist_feature["ocw_feature_url"] = url
+                        courselist_features.append(courselist_feature)
                 else:
                     for attr in courselist_feature_raw:
                         value = courselist_feature_raw[attr]
                         if value:
                             courselist_feature[attr] = value
-                courselist_features.append(courselist_feature)
+                    courselist_features.append(courselist_feature)
         new_json["courselist_features"] = courselist_features
         new_json["course_files"] = self.compose_media()
         new_json["course_embedded_media"] = self.compose_embedded_media()

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -178,6 +178,7 @@ def test_get_master_json(ocw_parser):
     assert master_json["title"], fail_template.format("title")
     assert master_json["description"], fail_template.format("description")
     assert master_json["short_url"], fail_template.format("short_url")
+    assert len(master_json["courselist_features"]) == 7, fail_template.format("courselist_features")
 
 
 def test_export_master_json_s3_links(ocw_parser_s3):

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -178,7 +178,7 @@ def test_get_master_json(ocw_parser):
     assert master_json["title"], fail_template.format("title")
     assert master_json["description"], fail_template.format("description")
     assert master_json["short_url"], fail_template.format("short_url")
-    assert len(master_json["courselist_features"]) == 7, fail_template.format("courselist_features")
+    assert len(master_json["open_learning_library_related"]) == 3, fail_template.format("open_learning_library_related")
 
 
 def test_export_master_json_s3_links(ocw_parser_s3):

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -179,7 +179,7 @@ def test_get_master_json(ocw_parser):
     assert master_json["description"], fail_template.format("description")
     assert master_json["short_url"], fail_template.format("short_url")
     assert len(master_json["open_learning_library_related"]) == 3, fail_template.format("open_learning_library_related")
-
+    assert master_json["open_learning_library_related"][0]["url"] == "https://openlearninglibrary.mit.edu/courses/course-v1:MITx+18.01.1x+2T2019/about"
 
 def test_export_master_json_s3_links(ocw_parser_s3):
     """

--- a/ocw_data_parser/test_json/course_dir/course-1/jsons/1.json
+++ b/ocw_data_parser/test_json/course_dir/course-1/jsons/1.json
@@ -4886,9 +4886,37 @@
     ], 
     "courselist_features": [
         {
+            "ocw_feature": "MITx", 
+            "ocw_subfeature": "8.02x Related OCW Courseware", 
+            "ocw_feature_url": "", 
+            "ocw_speciality": "", 
+            "ocw_feature_notes": ""
+        }, 
+        {
+            "ocw_feature": "MITx", 
+            "ocw_subfeature": "2.01x Related OCW Courseware", 
+            "ocw_feature_url": "", 
+            "ocw_speciality": "", 
+            "ocw_feature_notes": ""
+        }, 
+        {
+            "ocw_feature": "MITx", 
+            "ocw_subfeature": "8.01x Related OCW Courseware", 
+            "ocw_feature_url": "", 
+            "ocw_speciality": "", 
+            "ocw_feature_notes": ""
+        }, 
+        {
             "ocw_feature": "Crosslinks", 
             "ocw_subfeature": "", 
-            "ocw_feature_url": "http://crosslinks.mit.edu/topics/?query=subject18.06", 
+            "ocw_feature_url": "http://crosslinks.mit.edu/topics/?query=subject18.01", 
+            "ocw_speciality": "", 
+            "ocw_feature_notes": ""
+        }, 
+        {
+            "ocw_feature": "Open Learning Library", 
+            "ocw_subfeature": "", 
+            "ocw_feature_url": "18.01.1x Calculus 1A Differentiation::https://openlearninglibrary.mit.edu/courses/course-v1:MITx+18.01.1x+2T2019/about, 18.01.2x Calculus 1B Integration::https://openlearninglibrary.mit.edu/courses/course-v1:MITx+18.01.2x+3T2019/about,18.01.3x Calculus 1C Coordinate Systems & Infinite Series::https://openlearninglibrary.mit.edu/courses/course-v1:MITx+18.01.3x+1T2020/about", 
             "ocw_speciality": "", 
             "ocw_feature_notes": ""
         }

--- a/ocw_data_parser/test_json/course_dir/course-1/jsons/1.json
+++ b/ocw_data_parser/test_json/course_dir/course-1/jsons/1.json
@@ -4886,33 +4886,12 @@
     ], 
     "courselist_features": [
         {
-            "ocw_feature": "MITx", 
-            "ocw_subfeature": "8.02x Related OCW Courseware", 
-            "ocw_feature_url": "", 
-            "ocw_speciality": "", 
-            "ocw_feature_notes": ""
-        }, 
-        {
-            "ocw_feature": "MITx", 
-            "ocw_subfeature": "2.01x Related OCW Courseware", 
-            "ocw_feature_url": "", 
-            "ocw_speciality": "", 
-            "ocw_feature_notes": ""
-        }, 
-        {
-            "ocw_feature": "MITx", 
-            "ocw_subfeature": "8.01x Related OCW Courseware", 
-            "ocw_feature_url": "", 
-            "ocw_speciality": "", 
-            "ocw_feature_notes": ""
-        }, 
-        {
             "ocw_feature": "Crosslinks", 
             "ocw_subfeature": "", 
-            "ocw_feature_url": "http://crosslinks.mit.edu/topics/?query=subject18.01", 
+            "ocw_feature_url": "http://crosslinks.mit.edu/topics/?query=subject18.06", 
             "ocw_speciality": "", 
             "ocw_feature_notes": ""
-        }, 
+        },
         {
             "ocw_feature": "Open Learning Library", 
             "ocw_subfeature": "", 


### PR DESCRIPTION
This PR adds the "Open Learning Library" `ocw_feature` of `courselist_features` to master.json.  The data stored in the `ocw_feature_url` property on this is an array of comma separated key / value pairs with the course name and URL separated by `::`.  These pairs are parsed out and put into an array inside `open_learning_library_related`.

What are the relevant tickets?
Related to https://github.com/mitodl/ocw-data-parser/issues/53

