### PR TITLE
improve file parse error message

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -461,7 +461,12 @@ class OCWParser(object):
                     filename = uid + "_" + file.get("id")
                     if not get_binary_data(file):
                         log.error(
-                            "Could not load binary data for file: %s", filename)
+                            "Could not load binary data for file %s in json file %s for course %s",
+                            filename,
+                            file.get("actual_file_name"),
+                            self.master_json.get("short_url")
+                        )
+                        continue
                     else:
                         d = base64.b64decode(get_binary_data(file))
                     if upload_to_s3 and d:
@@ -494,7 +499,7 @@ class OCWParser(object):
                             self.master_json, bucket_base_url + filename)
                         log.info("Uploaded %s", filename)
                     else:
-                        log.error("Could NOT upload %s", filename)
+                        log.error("Could NOT upload %s for course %s", filename, self.master_json.get("short_url"))
                     update_file_location(
                         self.master_json, bucket_base_url + filename)
 
@@ -511,7 +516,7 @@ class OCWParser(object):
                                  Body=json.dumps(self.master_json),
                                  ACL='private')
         else:
-            log.error('No unique uid found for this master_json')
+            log.error("No unique uid found for master_json for course %s", self.master_json.get("short_url"))
 
     def upload_course_image(self):
         s3_bucket = self.get_s3_bucket()

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -115,6 +115,39 @@ def test_upload_all_data_to_s3(ocw_parser_s3, s3_bucket):
     assert master_json["thumbnail_image_src"] is not None
 
 
+def test_upload_all_data_to_s3_no_binary_data(ocw_parser_s3, caplog):
+    """
+    Test that there is a descriptive error message when there is no binary data in a json file
+    """
+    with patch("ocw_data_parser.ocw_data_parser.get_binary_data", return_value=None):
+        ocw_parser_s3.upload_all_media_to_s3()
+        assert "Could not load binary data for file 9dbd5e22e2379a1bb4e844757c445dfd_7UJ4CFRGd-U.srt "\
+        "in json file 15.json for course 18-06-linear-algebra-spring-2010" in [rec.message for rec in caplog.records]
+
+
+def test_upload_all_data_to_s3_large_media_link_upload_error(ocw_parser_s3, caplog):
+    """
+    Test that there is a descriptive error message when a large media file cannot be uploaded
+    """
+
+    with patch("ocw_data_parser.ocw_data_parser.get", return_value=None):
+        ocw_parser_s3.upload_all_media_to_s3()
+        assert "Could NOT upload powerMethod.html for course 18-06-linear-algebra-spring-2010" in [
+            rec.message for rec in caplog.records]
+
+
+
+def test_upload_master_json_to_s3_no_uid(ocw_parser_s3, caplog):
+    """
+    Test that there is a descriptive error message when the master json has no uid
+
+    """
+    ocw_parser_s3.master_json['uid']=None
+    ocw_parser_s3.upload_master_json_to_s3("testing")
+    assert "No unique uid found for master_json for course 18-06-linear-algebra-spring-2010" in [
+        rec.message for rec in caplog.records]
+
+
 def test_upload_course_image(ocw_parser_s3, s3_bucket):
     """
     Use moto (mock boto) to test s3 uploading


### PR DESCRIPTION
closes https://github.com/mitodl/ocw-data-parser/issues/50

To test:

Download Course 2.611 from s3://ocw-content-storage/PROD/2/2.611/Fall_2006/2-611-marine-power-and-propulsion-fall-2006/0/

Install the code from this branch with `pip3 install .`
from the python shell run
```
from ocw_data_parser import OCWParser
parser = OCWParser("./course/Fall_2006/2-611-marine-power-and-propulsion-fall-2006", "./destination/")
parser.setup_s3_uploading("odl-discussions-rc", key, secret)
parser.upload_all_media_to_s3()
```

Verify that you see the following errors:
```
Could not load binary data for file ef9780ba832dd6c46e5a8d2e58fb30ab_16pa6B_engine.pdf in json file 6.json for course 2-611-marine-power-and-propulsion-fall-2006
Could not load binary data for file 0d73eeef34debc57d43b2cd339ff0a96_16pa6b_engine.pdf in json file 7.json for course 2-611-marine-power-and-propulsion-fall-2006
Could not load binary data for file aac1729b9b17feeb93b9935e1a801e71_26stirling.avi in json file 30.json for course 2-611-marine-power-and-propulsion-fall-2006
```
