### PR TITLE
Remove safe_get

### DIFF
--- a/ocw_data_parser/__init__.py
+++ b/ocw_data_parser/__init__.py
@@ -1,4 +1,4 @@
 from ocw_data_parser.ocw_data_parser import CustomHTMLParser, OCWParser
 from ocw_data_parser.course_downloader import OCWDownloader
 from ocw_data_parser.static_html_generator import generate_html_for_course
-from ocw_data_parser.utils import update_file_location, get_binary_data, is_json, get_correct_path, load_json_file, print_error, print_success, safe_get, find_all_values_for_key, parse_all
+from ocw_data_parser.utils import update_file_location, get_binary_data, is_json, get_correct_path, load_json_file, print_error, print_success, find_all_values_for_key, parse_all

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -249,3 +249,52 @@ def test_uid(ocw_parser, course_id):
         with open(os.path.join(ocw_parser.destination_dir, "master/master.json"), "r") as master_json:
             master_json_data = json.loads(master_json.read())
             assert first_json_data["_uid"] == master_json_data["uid"]
+
+
+def test_course_files(ocw_parser):
+    """Make sure course_files include the right fields with the correct default values"""
+    assert len(ocw_parser.master_json['course_files']) == 172
+    assert ocw_parser.master_json['course_files'][0] == {
+        'order_index': 6,
+        'uid': 'c24518ecda658185c40c2e5eeb72c7fa',
+        'id': '182.png',
+        'parent_uid': '3f3b7835cf477d3ba10b05fbe03cbffa',
+        'title': '182.png',
+        'caption': '',
+        'file_type': 'image/png',
+        'alt_text': '',
+        'credit': '',
+        'platform_requirements': '',
+        'description': '',
+        'type': 'OCWImage',
+    }
+
+
+def test_other_information_text(ocw_parser):
+    """other_information_text should be an empty string"""
+    assert ocw_parser.master_json['other_information_text'] == ''
+
+
+def test_course_pages(ocw_parser):
+    """assert the output of composing course_pages"""
+    assert len(ocw_parser.master_json["course_pages"])
+    page = ocw_parser.master_json["course_pages"][0]
+    page_without_text = {**page}
+    del page_without_text["text"]
+    del page_without_text["description"]
+    assert page_without_text == {
+        'order_index': 3,
+        'uid': 'ede17211bd49ea166ed701f09c1de288',
+        'parent_uid': 'aabc44bdb2e45374d62f30f2a6d4c63e',
+        'title': 'Syllabus',
+        'short_page_title': 'Syllabus',
+        'type': 'CourseSection',
+        'is_image_gallery': False,
+        'is_media_gallery': False,
+        'list_in_left_nav': False,
+        'file_location': 'ede17211bd49ea166ed701f09c1de288_syllabus.html',
+        'short_url': 'syllabus',
+        'url': '/courses/mathematics/18-06-linear-algebra-spring-2010/syllabus',
+    }
+    assert page["text"].startswith("<h2 class=\"subhead\">Course Meeting Times")
+    assert page["description"].startswith("This syllabus section provides information on course goals")

--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -61,14 +61,6 @@ def print_success(message):
     print("\x1b[0;32;40m Success:\x1b[0m " + message)
 
 
-def safe_get(j, key, print_error_message=False):
-    value = j.get(key)
-    if value or isinstance(value, list):
-        return value
-    elif print_error_message:
-        log.error("%s: Value for %s is NOT found", (j["actual_file_name"], key))
-
-
 def find_all_values_for_key(jsons, key="_content_type"):
     excluded_values = ["text/plain", "text/html"]
     result = set()
@@ -83,9 +75,9 @@ def find_all_values_for_key(jsons, key="_content_type"):
     return result
 
 def htmlify(page):
-    safe_text = safe_get(page, "text")
+    safe_text = page.get("text")
     if safe_text:
-        file_name = safe_get(page, "uid") + "_" + safe_get(page, "short_url") + ".html"
+        file_name = page.get("uid") + "_" + page.get("short_url") + ".html"
         html = "<html><head></head><body>" + safe_text + "</body></html>"
         return file_name, html
     return None, None

--- a/ocw_data_parser/utils_test.py
+++ b/ocw_data_parser/utils_test.py
@@ -3,7 +3,8 @@ import json
 import pytest
 from tempfile import TemporaryDirectory
 import ocw_data_parser.test_constants as constants
-from ocw_data_parser.utils import update_file_location, get_binary_data, is_json, get_correct_path, load_json_file, print_error, print_success, safe_get, find_all_values_for_key, htmlify, parse_all
+from ocw_data_parser.utils import update_file_location, get_binary_data, get_correct_path, load_json_file, print_error, print_success, \
+    htmlify, parse_all
 
 
 def test_update_local_file_location(ocw_parser):
@@ -71,23 +72,12 @@ def test_print_success(ocw_parser):
     """
     print_success("Success!")
 
-def test_safe_get_invalid_value(ocw_parser):
-    """
-    Test trying to get a value from a dict that doesn't exist
-    """
-    test_dict = {
-        "value_one": "1",
-        "value_two": "2",
-        "actual_file_name": "test"
-    }
-    assert safe_get(test_dict, "value_three") is None
-
 def test_htmlify(ocw_parser):
     """
     Test that calling htmlify on a page returns some html and a filename
     """
     master_json = ocw_parser.get_master_json()
-    course_pages = safe_get(master_json, "course_pages")
+    course_pages = master_json.get("course_pages")
     test_page = course_pages[0]
     filename, html = htmlify(test_page)
     assert filename == test_page["uid"] + "_" + test_page["short_url"] + ".html"


### PR DESCRIPTION
Part of #56 

`safe_get` has the exact same behavior as `dict.get(...)` except that empty strings and `0` are handled incorrectly. I inlined all instances detected by pycharm, and I did some extra refactoring in `generate_master_json` though it should be just moving variables around.

There are some changes to the output, in particular `false` and `""` will be returned instead of `null`. You shouldn't see any other changes.

#### Manual testing
Convert a set of courses and compare the outputs. You should only see the empty string and `false` boolean values mentioned above.