### PR TITLE
Include bottomtext section in master JSON

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -211,6 +211,7 @@ class OCWParser(object):
                 "title": j.get("title"),
                 "short_page_title": j.get("short_page_title"),
                 "text": j.get("text"),
+                "bottomtext": j.get("bottomtext"),
                 "url": url_data,
                 "short_url": j.get("id"),
                 "description": j.get("description"),

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -178,6 +178,7 @@ def test_get_master_json(ocw_parser):
     assert master_json["title"], fail_template.format("title")
     assert master_json["description"], fail_template.format("description")
     assert master_json["short_url"], fail_template.format("short_url")
+    assert master_json["course_pages"][0]["bottomtext"], fail_template.format("bottomtext")
 
 
 def test_export_master_json_s3_links(ocw_parser_s3):

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -178,7 +178,6 @@ def test_get_master_json(ocw_parser):
     assert master_json["title"], fail_template.format("title")
     assert master_json["description"], fail_template.format("description")
     assert master_json["short_url"], fail_template.format("short_url")
-    assert master_json["course_pages"][0]["bottomtext"], fail_template.format("bottomtext")
 
 
 def test_export_master_json_s3_links(ocw_parser_s3):
@@ -287,6 +286,7 @@ def test_course_pages(ocw_parser):
         'file_location': 'ede17211bd49ea166ed701f09c1de288_syllabus.html',
         'short_url': 'syllabus',
         'url': '/courses/mathematics/18-06-linear-algebra-spring-2010/syllabus',
+        'bottomtext': '<p>Sample Bottom Text</p>'
     }
     assert page["text"].startswith("<h2 class=\"subhead\">Course Meeting Times")
     assert page["description"].startswith("This syllabus section provides information on course goals")

--- a/ocw_data_parser/test_json/course_dir/course-1/jsons/3.json
+++ b/ocw_data_parser/test_json/course_dir/course-1/jsons/3.json
@@ -81,7 +81,7 @@
     "effectiveDate": "2010/09/03 02:55:27.128 GMT-4", 
     "parent_module": "aabc44bdb2e45374d62f30f2a6d4c63e", 
     "is_mathml_document": false, 
-    "bottomtext": "", 
+    "bottomtext": "<p>Sample Bottom Text</p>",
     "short_page_title": "Syllabus", 
     "section_identifier": null, 
     "related_mit_links": "", 


### PR DESCRIPTION
#### What are the relevant tickets?
Partially addresses https://github.com/mitodl/hugo-course-publisher/issues/182

#### What's this PR do?
Includes `bottomtext` in the master JSON course pages section

#### How should this be manually tested?
- Tests should pass
- If you download and run the parser on course files for "PROD/EC/EC.711/Spring_2011/ec-711-d-lab-energy-spring-2011/", the resulting master JSON should include a `bottomtext` attribute containing the HTML at the [bottom of this page](https://ocw.mit.edu/courses/edgerton-center/ec-711-d-lab-energy-spring-2011/intro-energy-basics-human-power/).
