### PR TITLE
Provide an empty list if there are no instructors

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -166,11 +166,10 @@ class OCWParser(object):
             tags.append({"name": tag})
         new_json["tags"] = tags
         instructors = self.jsons[0].get("instructors")
-        if instructors:
-            new_json["instructors"] = [{key: value for key, value in instructor.items() if key != 'mit_id'}
-                                       for instructor in instructors]
-        else:
-            new_json["instructors"] = ""
+        new_json["instructors"] = [
+            {key: value for key, value in instructor.items() if key != 'mit_id'}
+             for instructor in instructors if instructors
+        ]
         new_json["language"] = self.jsons[0].get("language")
         new_json["extra_course_number"] = self.jsons[0].get("linked_course_number")
         new_json["course_collections"] = self.jsons[0].get("category_features")

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -289,3 +289,14 @@ def test_course_pages(ocw_parser):
     }
     assert page["text"].startswith("<h2 class=\"subhead\">Course Meeting Times")
     assert page["description"].startswith("This syllabus section provides information on course goals")
+
+
+@pytest.mark.parametrize("has_instructors", [True, False])
+def test_instructors(ocw_parser, has_instructors):
+    """instructors list should be present as a list in the output"""
+    expected_instructor = {**ocw_parser.jsons[0]["instructors"][0]}
+    if not has_instructors:
+        ocw_parser.jsons[0]["instructors"] = []
+    ocw_parser.generate_master_json()
+    del expected_instructor["mit_id"]
+    assert ocw_parser.master_json["instructors"] == ([expected_instructor] if has_instructors else [])


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #61 

#### What's this PR do?
Changes the return value for instructors to be an empty list if there are no instructors

#### How should this be manually tested?
I'm not sure, are there any courses without any instructors? You could try editing the instructors list in `1.json` to be an empty list temporarily and make sure it converts properly.
