### PR TITLE
add master_subject array to master json

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -310,7 +310,7 @@ class OCWParser(object):
             "sort_as": self.jsons[0].get("sort_as"),
             "department_number": master_course.split('.')[0] if master_course else "",
             "master_course_number": master_course.split('.')[1] if master_course else "",
-            "master_subject_uid": self.jsons[0].get("master_subject"),
+            "master_subject_uids": self.jsons[0].get("master_subject"),
             "from_semester": self.jsons[0].get("from_semester"),
             "from_year": self.jsons[0].get("from_year"),
             "to_semester": self.jsons[0].get("to_semester"),

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -310,6 +310,7 @@ class OCWParser(object):
             "sort_as": self.jsons[0].get("sort_as"),
             "department_number": master_course.split('.')[0] if master_course else "",
             "master_course_number": master_course.split('.')[1] if master_course else "",
+            "master_subject_uid": self.jsons[0].get("master_subject"),
             "from_semester": self.jsons[0].get("from_semester"),
             "from_year": self.jsons[0].get("from_year"),
             "to_semester": self.jsons[0].get("to_semester"),

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -310,7 +310,7 @@ class OCWParser(object):
             "sort_as": self.jsons[0].get("sort_as"),
             "department_number": master_course.split('.')[0] if master_course else "",
             "master_course_number": master_course.split('.')[1] if master_course else "",
-            "master_subject_uids": self.jsons[0].get("master_subject"),
+            "other_version_parent_uids": self.jsons[0].get("master_subject"),
             "from_semester": self.jsons[0].get("from_semester"),
             "from_year": self.jsons[0].get("from_year"),
             "to_semester": self.jsons[0].get("to_semester"),

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -300,6 +300,10 @@ def test_other_information_text(ocw_parser):
     """other_information_text should be an empty string"""
     assert ocw_parser.master_json['other_information_text'] == ''
 
+def test_other_version_parent_uids(ocw_parser):
+    """Make sure other_version_parent_subjects includes a list containing one UID"""
+    assert ocw_parser.master_json['other_version_parent_uids'][0] == "c57db32e19cecbfe65656ede124729fb"
+    assert len(ocw_parser.master_json['other_version_parent_uids']) == 1
 
 def test_course_pages(ocw_parser):
     """assert the output of composing course_pages"""


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-data-parser/issues/53

#### What's this PR do?
This PR adds the `master_subject_uids` property to master json, based on the `master_subject` property in 1.json files, which is an array (usually only containing one item) of UID's.  These UID's don't seem to refer to any specific course, rather they refer to a "master subject" which are objects stored in Plone: https://ocw-qa.odl.mit.edu/mastersubjects/manage_main

This information will be used to build a reverse lookup during conversions in `ocw-to-hugo` to generate Other OCW Version links.

#### How should this be manually tested?
Convert any number of courses and ensure that the `master_subject_uids` field appears in master json and has a value set on it that in most cases will be an array with a single UID in it.  Some courses may have multiple.
