### PR TITLE
Add option to upload master json to s3 in parse_all function

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -513,9 +513,9 @@ class OCWParser(object):
                         self.master_json, bucket_base_url + filename)
 
     def upload_all_media_to_s3(self, upload_master_json=False):
-        s3_bucket = self.get_s3_bucket()
         self.update_s3_content()
         if upload_master_json:
+            s3_bucket = self.get_s3_bucket()
             self.upload_master_json_to_s3(s3_bucket)
 
     def upload_master_json_to_s3(self, s3_bucket):

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -395,9 +395,9 @@ class OCWParser(object):
                  path_to_containing_folder)
         self.export_master_json()
 
-    def export_master_json(self, s3_links=False):
+    def export_master_json(self, s3_links=False, upload_master_json=False):
         if s3_links:
-            self.update_s3_content()
+            self.upload_all_media_to_s3(upload_master_json=upload_master_json)
         os.makedirs(self.destination_dir + "master/", exist_ok=True)
         file_path = self.destination_dir + "master/master.json"
         with open(file_path, "w") as file:

--- a/ocw_data_parser/utils_test.py
+++ b/ocw_data_parser/utils_test.py
@@ -174,14 +174,15 @@ def test_is_course_published(last_published, last_unpublished, is_published):
         "last_published_to_production": last_published,
         "last_unpublishing_date": last_unpublished,
     }
-    with patch("os.path.exists", return_value=True):
-        with patch("json.load", return_value=sample_json):
-            assert (
-                is_course_published(
-                    "{}/".format(os.path.join(constants.COURSE_DIR, "course-1"))
-                )
-                == is_published
+    with patch("os.path.exists", return_value=True), patch(
+        "json.load", return_value=sample_json
+    ):
+        assert (
+            is_course_published(
+                "{}/".format(os.path.join(constants.COURSE_DIR, "course-1"))
             )
+            == is_published
+        )
 
 
 def test_is_course_published_not_found():
@@ -203,15 +204,16 @@ def test_is_course_published_bad_data():
         "last_published_to_production": "a b",
         "last_unpublishing_date": "TBA",
     }
-    with patch("ocw_data_parser.utils.log.error") as mock_log:
-        with patch("os.path.exists", return_value=True):
-            with patch("ocw_data_parser.utils.glob", return_value=["1.json"]):
-                with patch("json.load", return_value=sample_json):
-                    is_course_published(
-                        "{}/".format(os.path.join(constants.COURSE_DIR, "course-1"))
-                    )
-                    mock_log.assert_called_once_with(
-                        "Error encountered reading 1.json for %s",
-                        "ocw_data_parser/test_json/course_dir/course-1/",
-                        exc_info=True,
-                    )
+    with patch("ocw_data_parser.utils.log.error") as mock_log, patch(
+        "os.path.exists", return_value=True
+    ), patch("ocw_data_parser.utils.glob", return_value=["1.json"]), patch(
+        "json.load", return_value=sample_json
+    ):
+        is_course_published(
+            "{}/".format(os.path.join(constants.COURSE_DIR, "course-1"))
+        )
+        mock_log.assert_called_once_with(
+            "Error encountered reading 1.json for %s",
+            "ocw_data_parser/test_json/course_dir/course-1/",
+            exc_info=True,
+        )

--- a/ocw_data_parser/utils_test.py
+++ b/ocw_data_parser/utils_test.py
@@ -123,7 +123,9 @@ def test_htmlify(ocw_parser):
 
 
 def test_parse_all():
-    """ Test that all expected master json files are written to the output directory"""
+    """
+    Test that all expected master json files are written to the output directory
+    """
     with TemporaryDirectory() as destination_dir:
         parse_all(constants.COURSE_DIR, destination_dir)
         assert os.path.isdir(os.path.join(destination_dir, "course-1"))
@@ -134,7 +136,9 @@ def test_parse_all():
 @pytest.mark.parametrize("s3_links", [True, False])
 @pytest.mark.parametrize("is_published", [True, False])
 def test_parse_all(upload_master_json, s3_links, is_published):
-    """ Test that OCWParser.export_master_json is called with the expected arguments """
+    """
+    Test that OCWParser.export_master_json is called with the expected arguments
+    """
     with patch("ocw_data_parser.utils.is_course_published", return_value=is_published):
         with patch("ocw_data_parser.OCWParser") as mock_parser:
             with TemporaryDirectory() as destination_dir:
@@ -163,7 +167,9 @@ def test_parse_all(upload_master_json, s3_links, is_published):
     ],
 )
 def test_is_course_published(last_published, last_unpublished, is_published):
-    """ Test that the expected value is returned from is_course_published """
+    """
+    Test that the expected value is returned from is_course_published
+    """
     sample_json = {
         "last_published_to_production": last_published,
         "last_unpublishing_date": last_unpublished,
@@ -179,7 +185,9 @@ def test_is_course_published(last_published, last_unpublished, is_published):
 
 
 def test_is_course_published_not_found():
-    """ Test that an error is logged if the 1.json can't be found """
+    """
+    Test that an error is logged if 1.json can't be found
+    """
     with patch("ocw_data_parser.utils.log.error") as mock_log:
         is_course_published("/fake_path")
         mock_log.assert_called_once_with(
@@ -188,7 +196,9 @@ def test_is_course_published_not_found():
 
 
 def test_is_course_published_bad_data():
-    """ Test that an error is logged if the 1.json can't be parsed for dates """
+    """
+    Test that an error is logged if 1.json can't be parsed for dates
+    """
     sample_json = {
         "last_published_to_production": "a b",
         "last_unpublishing_date": "TBA",

--- a/ocw_data_parser/utils_test.py
+++ b/ocw_data_parser/utils_test.py
@@ -2,56 +2,87 @@ import os
 import json
 import pytest
 from tempfile import TemporaryDirectory
+
+from mock import patch
+
 import ocw_data_parser.test_constants as constants
-from ocw_data_parser.utils import update_file_location, get_binary_data, get_correct_path, load_json_file, print_error, print_success, \
-    htmlify, parse_all
+from ocw_data_parser.utils import (
+    update_file_location,
+    get_binary_data,
+    get_correct_path,
+    load_json_file,
+    print_error,
+    print_success,
+    htmlify,
+    parse_all,
+    is_course_published,
+)
 
 
 def test_update_local_file_location(ocw_parser):
     """
-    Extract local course media, update the location of one of the files 
+    Extract local course media, update the location of one of the files
     and then assert that the location has indeed changed
     """
     ocw_parser.extract_media_locally()
-    assert len(ocw_parser.master_json["course_files"]) > 0, "test course has no local media to test"
+    assert (
+        len(ocw_parser.master_json["course_files"]) > 0
+    ), "test course has no local media to test"
     test_file = ocw_parser.master_json["course_files"][0]
     original_location = test_file["file_location"]
-    update_file_location(ocw_parser.master_json,
-                            "test_location", obj_uid=test_file["uid"])
-    assert original_location != ocw_parser.master_json["course_files"][0]["file_location"], "failed to update local file location"
+    update_file_location(
+        ocw_parser.master_json, "test_location", obj_uid=test_file["uid"]
+    )
+    assert (
+        original_location != ocw_parser.master_json["course_files"][0]["file_location"]
+    ), "failed to update local file location"
+
 
 def test_update_foreign_file_location(ocw_parser):
     """
-    Extract foreign course media, update the location of one of the files 
+    Extract foreign course media, update the location of one of the files
     and then assert that the location has indeed changed
     """
     ocw_parser.extract_foreign_media_locally()
-    assert len(ocw_parser.master_json["course_foreign_files"]) > 0, "test course has no foreign media to test"
+    assert (
+        len(ocw_parser.master_json["course_foreign_files"]) > 0
+    ), "test course has no foreign media to test"
     test_file = ocw_parser.master_json["course_foreign_files"][0]
     original_location = test_file["file_location"]
     original_filename = test_file["link"].split("/")[-1]
-    update_file_location(ocw_parser.master_json,
-                            os.path.join("test_location/", original_filename))
-    assert original_location != ocw_parser.master_json["course_foreign_files"][0]["file_location"], "failed to update foreign file location"
+    update_file_location(
+        ocw_parser.master_json, os.path.join("test_location/", original_filename)
+    )
+    assert (
+        original_location
+        != ocw_parser.master_json["course_foreign_files"][0]["file_location"]
+    ), "failed to update foreign file location"
+
 
 def test_get_binary_data_none(ocw_parser):
     """
     Find the first file without a datafield property and attempt to get the binary data from it
     """
-    assert len(ocw_parser.master_json["course_files"]) > 0, "test course has no local media to test"
+    assert (
+        len(ocw_parser.master_json["course_files"]) > 0
+    ), "test course has no local media to test"
     found = False
     for media in ocw_parser.master_json["course_files"]:
         if "_datafield_image" not in media and "_datafield_file" not in media:
             found = True
             data = get_binary_data(media)
-            assert data is None, "unexpected binary data in non _datafield_image or _datafield_file media"
+            assert (
+                data is None
+            ), "unexpected binary data in non _datafield_image or _datafield_file media"
     assert found, "test course has no file without a datafield property"
+
 
 def test_get_correct_path_none(ocw_parser):
     """
     Test passing in invalid data to get_correct_path
     """
     assert get_correct_path(None) == ""
+
 
 def test_load_invalid_json_file(ocw_parser):
     """
@@ -60,17 +91,20 @@ def test_load_invalid_json_file(ocw_parser):
     with pytest.raises(json.decoder.JSONDecodeError):
         load_json_file("ocw_data_parser/ocw_data_parser_test.py")
 
+
 def test_print_error(ocw_parser):
     """
     Test printing an error doesn't throw an exception
     """
     print_error("Error!")
 
+
 def test_print_success(ocw_parser):
     """
     Test that printing a success message doesn't throw an exception
     """
     print_success("Success!")
+
 
 def test_htmlify(ocw_parser):
     """
@@ -87,8 +121,92 @@ def test_htmlify(ocw_parser):
     assert "</body>" in html
     assert test_page["text"] in html
 
-def test_parse_all():
+
+def test_parse_all(upload_master_json, s3_links, is_published):
+    """ Test that all expected master json files are written to the output directory"""
     with TemporaryDirectory() as destination_dir:
-        parse_all(constants.COURSE_DIR, destination_dir)
+        parse_all(
+            constants.COURSE_DIR,
+            destination_dir,
+            s3_links=s3_links,
+            upload_master_json=upload_master_json,
+        )
         assert os.path.isdir(os.path.join(destination_dir, "course-1"))
         assert os.path.isdir(os.path.join(destination_dir, "course-2"))
+
+
+@pytest.mark.parametrize("upload_master_json", [True, False])
+@pytest.mark.parametrize("s3_links", [True, False])
+@pytest.mark.parametrize("is_published", [True, False])
+def test_parse_all(upload_master_json, s3_links, is_published):
+    """ Test that OCWParser.export_master_json is called with the expected arguments """
+    with patch("ocw_data_parser.utils.is_course_published", return_value=is_published):
+        with patch("ocw_data_parser.OCWParser") as mock_parser:
+            with TemporaryDirectory() as destination_dir:
+                parse_all(
+                    constants.COURSE_DIR,
+                    destination_dir,
+                    s3_links=s3_links,
+                    upload_master_json=upload_master_json,
+                )
+                assert mock_parser.return_value.export_master_json.call_count == 2
+                mock_parser.return_value.export_master_json.assert_any_call(
+                    s3_links=s3_links,
+                    upload_master_json=(
+                        s3_links and is_published and upload_master_json
+                    ),
+                )
+
+
+@pytest.mark.parametrize(
+    "last_published,last_unpublished,is_published",
+    [
+        [None, None, False],
+        ["2016/02/02 20:28:06 US/Eastern", None, True],
+        ["2016/02/02 20:28:06 US/Eastern", "2015/02/02 20:28:06 US/Eastern", True],
+        ["2016/02/02 20:28:06 US/Eastern", "2018/02/02 20:28:06 US/Eastern", False],
+    ],
+)
+def test_is_course_published(last_published, last_unpublished, is_published):
+    """ Test that the expected value is returned from is_course_published """
+    sample_json = {
+        "last_published_to_production": last_published,
+        "last_unpublishing_date": last_unpublished,
+    }
+    with patch("os.path.exists", return_value=True):
+        with patch("json.load", return_value=sample_json):
+            assert (
+                is_course_published(
+                    "{}/".format(os.path.join(constants.COURSE_DIR, "course-1"))
+                )
+                == is_published
+            )
+
+
+def test_is_course_published_not_found():
+    """ Test that an error is logged if the 1.json can't be found """
+    with patch("ocw_data_parser.utils.log.error") as mock_log:
+        is_course_published("/fake_path")
+        mock_log.assert_called_once_with(
+            "Could not find 1.json for %s", "/fake_path", exc_info=True
+        )
+
+
+def test_is_course_published_bad_data():
+    """ Test that an error is logged if the 1.json can't be parsed for dates """
+    sample_json = {
+        "last_published_to_production": "a b",
+        "last_unpublishing_date": "TBA",
+    }
+    with patch("ocw_data_parser.utils.log.error") as mock_log:
+        with patch("os.path.exists", return_value=True):
+            with patch("ocw_data_parser.utils.glob", return_value=["1.json"]):
+                with patch("json.load", return_value=sample_json):
+                    is_course_published(
+                        "{}/".format(os.path.join(constants.COURSE_DIR, "course-1"))
+                    )
+                    mock_log.assert_called_once_with(
+                        "Error encountered reading 1.json for %s",
+                        "ocw_data_parser/test_json/course_dir/course-1/",
+                        exc_info=True,
+                    )

--- a/ocw_data_parser/utils_test.py
+++ b/ocw_data_parser/utils_test.py
@@ -122,15 +122,10 @@ def test_htmlify(ocw_parser):
     assert test_page["text"] in html
 
 
-def test_parse_all(upload_master_json, s3_links, is_published):
+def test_parse_all():
     """ Test that all expected master json files are written to the output directory"""
     with TemporaryDirectory() as destination_dir:
-        parse_all(
-            constants.COURSE_DIR,
-            destination_dir,
-            s3_links=s3_links,
-            upload_master_json=upload_master_json,
-        )
+        parse_all(constants.COURSE_DIR, destination_dir)
         assert os.path.isdir(os.path.join(destination_dir, "course-1"))
         assert os.path.isdir(os.path.join(destination_dir, "course-2"))
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #75 

#### What's this PR do?
Adds a `upload_master_json` boolean keyword argument to `parse_all`.  If this is `True`, and the `s3_links` argument is True, and the course is published (code has been copied over from open to determine this), then the master JSON file will be uploaded to S3.  

#### How should this be manually tested?
Before running:
```
export export AWS_ACCESS_KEY_ID=<value for CI>
export AWS_SECRET_ACCESS_KEY=<value for CI>
```

Then in a shell:
```python
from ocw_data_parser.utils import *
bucket_name="open-learning-course-data-ci"
parse_all(
    "raw", 
    "output", 
    s3_bucket=bucket_name,
    s3_links=True,
    overwrite=True,
    beautify_master_json=True,
    upload_master_json=True
)
```

Then check to see that the master JSON in S3 is recent and matches what was written to the output directory:
```
import boto3
import json

s3 = boto3.resource(
    "s3",
    aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"], 
    aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"]
)
# Assuming the course processed was cms-611j-creating-video-games-fall-2014
obj = s3.Object(
    bucket_name, 
    'cms-611j-creating-video-games-fall-2014/407b4d7bd6da663d702c00152b0195fd_master.json'
)

obj.last_modified

obj.download_file('output2/s3.json')

with open("output2/cms-611j-creating-video-games-fall-2014/master/master.json") as inf:
    a = json.load(inf)
with open("output2/s3.json") as inf:
    b = json.load(inf)
json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
```


#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)
