### PR TITLE
Download S3 files to original full path and adjust parse_all to find them

### DIFF
--- a/ocw_data_parser/course_downloader.py
+++ b/ocw_data_parser/course_downloader.py
@@ -13,10 +13,11 @@ An example of the expected format can be found in example_courses.json
 class OCWDownloader(object):
     def __init__(self,
                  courses_json="",
+                 prefix="PROD",
                  destination_dir="",
                  s3_bucket_name="",
                  overwrite=False,
-                 prefix="PROD"):
+        ):
         self.courses_json = courses_json
         self.destination_dir = destination_dir
         self.s3_bucket_name = s3_bucket_name

--- a/ocw_data_parser/course_downloader.py
+++ b/ocw_data_parser/course_downloader.py
@@ -43,7 +43,7 @@ class OCWDownloader(object):
                     if course_id in courses:
                         # make the destination path if it doesn't exist and download all files
                         raw_course_path = os.path.join(
-                            self.destination_dir, "/".join(key_parts[0:-1]))
+                            self.destination_dir, *key_parts[0:-1])
                         if not os.path.exists(raw_course_path):
                             os.makedirs(raw_course_path)
                         dest_filename = os.path.join(

--- a/ocw_data_parser/course_downloader.py
+++ b/ocw_data_parser/course_downloader.py
@@ -13,15 +13,15 @@ An example of the expected format can be found in example_courses.json
 class OCWDownloader(object):
     def __init__(self,
                  courses_json="",
-                 env="QA",
                  destination_dir="",
                  s3_bucket_name="",
-                 overwrite=False):
+                 overwrite=False,
+                 prefix="PROD"):
         self.courses_json = courses_json
-        self.env = env
         self.destination_dir = destination_dir
         self.s3_bucket_name = s3_bucket_name
         self.overwrite = overwrite
+        self.prefix = prefix
 
     def download_courses(self):
         courses = None
@@ -37,12 +37,12 @@ class OCWDownloader(object):
         for page in pages:
             for obj in page["Contents"]:
                 key_parts = obj["Key"].split("/")
-                if len(key_parts) > 3:
+                if len(key_parts) > 3 and key_parts[0] == self.prefix:
                     course_id = key_parts[-3]
                     if course_id in courses:
                         # make the destination path if it doesn't exist and download all files
                         raw_course_path = os.path.join(
-                            self.destination_dir, course_id, "0")
+                            self.destination_dir, "/".join(key_parts[0:-1]))
                         if not os.path.exists(raw_course_path):
                             os.makedirs(raw_course_path)
                         dest_filename = os.path.join(

--- a/ocw_data_parser/course_downloader_test.py
+++ b/ocw_data_parser/course_downloader_test.py
@@ -12,6 +12,7 @@ import ocw_data_parser.test_constants as constants
 Tests for course_downlader
 """
 
+
 def test_download_courses(ocw_downloader):
     """
     Use moto (mock boto) to test s3 downloading and make sure all files 
@@ -25,8 +26,9 @@ def test_download_courses(ocw_downloader):
                 path, course = os.path.split(path)
                 for json_file in files:
                     test_data_path = os.path.join(path, course, "jsons", json_file)
-                    downloaded_path = os.path.join(ocw_downloader.destination_dir, course, "0", json_file)
+                    downloaded_path = os.path.join(ocw_downloader.destination_dir, constants.S3_TEST_COURSE_ROOT, course, "0", json_file)
                     assert filecmp.cmp(test_data_path, downloaded_path)
+
 
 def test_download_courses_no_destination_dir(ocw_downloader):
     """
@@ -38,6 +40,18 @@ def test_download_courses_no_destination_dir(ocw_downloader):
         ocw_downloader.download_courses()
         mock.assert_any_call(ocw_downloader.destination_dir)
 
+
+def test_download_courses_skip_nonmatching_prefix(ocw_downloader):
+    """
+    Download the courses, but delete the destination dir first, then ensure 
+    the process runs without error and the directory is recreated
+    """
+    ocw_downloader.prefix = "QA"
+    ocw_downloader.download_courses()
+    downloaded_path = os.path.join(ocw_downloader.destination_dir, constants.S3_TEST_COURSE_ROOT)
+    assert os.path.exists(downloaded_path) is False
+
+
 def test_download_courses_missing_course(ocw_downloader, capfd):
     """
     Download the courses, but add a course to courses.json that doesn't exist first
@@ -46,6 +60,7 @@ def test_download_courses_missing_course(ocw_downloader, capfd):
     ocw_downloader.download_courses()
     out, err = capfd.readouterr()
     assert "missing was not found in the s3 bucket testing" in out
+
 
 def test_download_courses_overwrite(ocw_downloader):
     """

--- a/ocw_data_parser/course_downloader_test.py
+++ b/ocw_data_parser/course_downloader_test.py
@@ -41,15 +41,15 @@ def test_download_courses_no_destination_dir(ocw_downloader):
         mock.assert_any_call(ocw_downloader.destination_dir)
 
 
-def test_download_courses_skip_nonmatching_prefix(ocw_downloader):
+@pytest.mark.parametrize("prefix,downloaded", [["PROD", True], ["QA", False]])
+def test_download_courses_skip_nonmatching_prefix(ocw_downloader, prefix, downloaded):
     """
-    Download the courses, but delete the destination dir first, then ensure 
-    the process runs without error and the directory is recreated
+    Courses that don't match the specified prefix should not be downloaded
     """
-    ocw_downloader.prefix = "QA"
+    ocw_downloader.prefix = prefix
     ocw_downloader.download_courses()
     downloaded_path = os.path.join(ocw_downloader.destination_dir, constants.S3_TEST_COURSE_ROOT)
-    assert os.path.exists(downloaded_path) is False
+    assert os.path.exists(downloaded_path) is downloaded
 
 
 def test_download_courses_missing_course(ocw_downloader, capfd):

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -473,5 +473,5 @@ def test_extract_media_locally(ocw_parser):
 
 def test_publish_date(ocw_parser):
     """Assert that we get first_published_to_production and last_published_to_production"""
-    assert ocw_parser.master_json["first_published_to_production"] == "2010/09/10 10:23:13.887 GMT-4"
-    assert ocw_parser.master_json["last_published_to_production"] == "2019/09/25 17:47:34.670 Universal"
+    assert ocw_parser.parsed_json["first_published_to_production"] == "2010/09/10 10:23:13.887 GMT-4"
+    assert ocw_parser.parsed_json["last_published_to_production"] == "2019/09/25 17:47:34.670 Universal"

--- a/ocw_data_parser/test_constants.py
+++ b/ocw_data_parser/test_constants.py
@@ -5,4 +5,4 @@ COURSE_1_ID = "res-str-001-geographic-information-system-gis-tutorial-january-ia
 COURSE_2_ID = "18-06-linear-algebra-spring-2010"
 SINGLE_COURSE_DIR = os.path.join(COURSE_DIR, "course-1")
 STATIC_PREFIX = "static_files/"
-S3_TEST_COURSE_ROOT = os.path.join("QA", "Department", "CourseNumber", "Term")
+S3_TEST_COURSE_ROOT = os.path.join("PROD", "Department", "CourseNumber", "Term")


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #80 

#### What's this PR do?
Modifies OCWDownloader to retain the original S3 bucket path when downloading to the local filesystem.
Modifies the `parse_all` function to find course files in this path structure

#### How should this be manually tested?
```python
from ocw_data_parser import OCWDownloader
downloader = OCWDownloader("example_courses.json", "PROD", "local", "ocw-content-storage")
downloader.download_courses()
```
Files should be saved under "local/PROD/<department>/<course_number>/<semester_year>/<course_slug>/0"

Then run:
```python
from ocw_data_parser.utils import *
bucket_name="open-learning-course-data-ci"
parse_all(
    "local", 
    "output", 
    s3_bucket=bucket_name,
    s3_links=True,
    overwrite=True,
    beautify_master_json=True,
    upload_master_json=False
)
```

Check that master_json is written to the output folder

