### PR TITLE
Turn off codecov checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: no
+    patch:
+      default:
+        enabled: no
+    changes:
+      default:
+        enabled: no

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 moto
 pytest-cov
 codecov
+responses==0.12.0


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #86 

#### What's this PR do?
Turns off codecov checks during a build. Code coverage should still be uploaded to codecov.io

#### How should this be manually tested?
Verify that there are no checks for code coverage in the section below
