### PR TITLE
Fix null instructors error

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -328,8 +328,8 @@ class OCWParser(object):
             "tags": [{"name": tag} for tag in self.jsons[0].get("subject")],
             "instructors": [
                 {key: value for key, value in instructor.items() if key != 'mit_id'}
-                 for instructor in instructors if instructors
-            ],
+                 for instructor in instructors
+            ] if instructors else [],
             "language": self.jsons[0].get("language"),
             "extra_course_number": self.jsons[0].get("linked_course_number"),
             "course_collections": self.jsons[0].get("category_features"),

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -336,7 +336,7 @@ def test_instructors(ocw_parser, has_instructors):
     """instructors list should be present as a list in the output"""
     expected_instructor = {**ocw_parser.jsons[0]["instructors"][0]}
     if not has_instructors:
-        ocw_parser.jsons[0]["instructors"] = []
+        ocw_parser.jsons[0]["instructors"] = None
     ocw_parser.generate_parsed_json()
     del expected_instructor["mit_id"]
     assert ocw_parser.parsed_json["instructors"] == ([expected_instructor] if has_instructors else [])

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 moto
 pytest-cov
 codecov
+responses==0.12.0


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes an error parsing `15-071-the-analytics-edge-spring-2017`

#### How should this be manually tested?
Put the input course in a directory, then run `parse_all` on that directory
