### PR TITLE
fix upload_parsed_json argument in parse_all

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,7 @@ To parse a folder of course folders (like the ones downloaded above) and export 
 ```python
 from ocw_data_parser import parse_all
 
-parse_all(courses_dir="private/raw_courses", destination_dir="../ocw-to-hugo/private/courses", s3_bucket="open-learning-course-data-ci", s3_links=True, overwrite=True, beautify_parsed_json=True)
+parse_all(courses_dir="private/raw_courses", destination_dir="../ocw-to-hugo/private/courses", upload_parsed_json=False, s3_bucket="open-learning-course-data-ci", s3_links=True, overwrite=True, beautify_parsed_json=True)
 ```
+
+If you desire to upload the parsed JSON to S3, simply set `upload_parsed_json` to `True`.

--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -155,11 +155,11 @@ def is_course_published(source_path):
 def parse_all(
     courses_dir,
     destination_dir,
+    upload_parsed_json,
     s3_bucket="",
     s3_links=False,
     overwrite=False,
-    beautify_parsed_json=False,
-    upload_parsed_json=False,
+    beautify_parsed_json=False
 ):
     for root, dirs, files in os.walk(courses_dir):
         if len(dirs) == 0 and len(files) > 0:
@@ -179,10 +179,10 @@ def parse_all(
                         s3_target_folder=course_dir,
                         beautify_parsed_json=beautify_parsed_json,
                     )
-                    upload_parsed_json = (
+                    perform_upload = (
                         s3_links and upload_parsed_json and is_course_published(source_path)
                         )
-                    if upload_parsed_json:
+                    if perform_upload:
                         parser.setup_s3_uploading(
                             s3_bucket,
                             os.environ["AWS_ACCESS_KEY_ID"],
@@ -192,5 +192,5 @@ def parse_all(
                     # just upload parsed json, and update media links.
                         parser.upload_to_s3 = False
                     parser.export_parsed_json(
-                        s3_links=s3_links, upload_parsed_json=upload_parsed_json
+                        s3_links=s3_links, upload_parsed_json=perform_upload
                     )


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-data-parser/issues/93

#### What's this PR do?
This PR moves `upload_parsed_json` to a positional argument.  Also instead of modifying the value of this variable to include the s3_links and is_course_published checks, this value is assigned to a new variable so that the value of the argument is not set for subsequent calls.

#### How should this be manually tested?
Try running `parse_all` for a folder containing multiple courses from `ocw-content-storage` with `upload_parsed_json` set to True and ensure that all parsed json files are properly uploaded.
