### PR TITLE
Refactor to use pathlib

### DIFF
--- a/ocw_data_parser/__init__.py
+++ b/ocw_data_parser/__init__.py
@@ -1,3 +1,3 @@
 from ocw_data_parser.ocw_data_parser import CustomHTMLParser, OCWParser
 from ocw_data_parser.course_downloader import OCWDownloader
-from ocw_data_parser.utils import update_file_location, get_binary_data, is_json, get_correct_path, load_json_file, print_error, print_success, find_all_values_for_key, parse_all
+from ocw_data_parser.utils import update_file_location, get_binary_data, print_error, print_success, find_all_values_for_key, parse_all

--- a/ocw_data_parser/course_downloader.py
+++ b/ocw_data_parser/course_downloader.py
@@ -1,5 +1,5 @@
 import os
-import shutil
+from pathlib import Path
 import json
 import boto3
 
@@ -10,27 +10,25 @@ An example of the expected format can be found in example_courses.json
 """
 
 
-class OCWDownloader(object):
+class OCWDownloader:
     def __init__(self,
-                 courses_json="",
+                 courses_json=None,
                  prefix="PROD",
-                 destination_dir="",
+                 destination_dir=None,
                  s3_bucket_name="",
                  overwrite=False,
         ):
-        self.courses_json = courses_json
-        self.destination_dir = destination_dir
+        self.courses_json = Path(courses_json) if courses_json else None
+        self.destination_dir = Path(destination_dir) if destination_dir else None
         self.s3_bucket_name = s3_bucket_name
         self.overwrite = overwrite
         self.prefix = prefix
 
     def download_courses(self):
-        courses = None
         downloaded_courses = []
         with open(self.courses_json) as f:
             courses = json.load(f)["courses"]
-        if not os.path.exists(self.destination_dir):
-            os.makedirs(self.destination_dir)
+        os.makedirs(self.destination_dir, exist_ok=True)
         s3_client = boto3.client("s3")
 
         paginator = s3_client.get_paginator("list_objects")
@@ -42,15 +40,14 @@ class OCWDownloader(object):
                     course_id = key_parts[-3]
                     if course_id in courses:
                         # make the destination path if it doesn't exist and download all files
-                        raw_course_path = os.path.join(
+                        raw_course_path = Path(
                             self.destination_dir, *key_parts[0:-1])
-                        if not os.path.exists(raw_course_path):
-                            os.makedirs(raw_course_path)
-                        dest_filename = os.path.join(
-                            raw_course_path, os.path.basename(os.path.normpath(obj["Key"])))
-                        if (os.path.exists(dest_filename) and self.overwrite):
+                        os.makedirs(raw_course_path, exist_ok=True)
+                        key_basename = os.path.basename(os.path.normpath(obj["Key"]))
+                        dest_filename = raw_course_path / key_basename
+                        if dest_filename.exists() and self.overwrite:
                             os.remove(dest_filename)
-                        if not os.path.exists(dest_filename):
+                        if not dest_filename.exists():
                             print("downloading {}...".format(
                                 dest_filename))
                             with open(dest_filename, "wb+") as f:

--- a/ocw_data_parser/course_downloader_test.py
+++ b/ocw_data_parser/course_downloader_test.py
@@ -1,9 +1,9 @@
 import os
+from pathlib import Path
 import shutil
 import pytest
 from mock import patch
 import filecmp
-from tempfile import TemporaryDirectory
 import logging
 log = logging.getLogger(__name__)
 import ocw_data_parser.test_constants as constants
@@ -35,10 +35,10 @@ def test_download_courses_no_destination_dir(ocw_downloader):
     Download the courses, but delete the destination dir first, then ensure 
     the process runs without error and the directory is recreated
     """
-    with patch.object(os, "makedirs", wraps=os.makedirs) as mock:
+    with patch("os.makedirs", wraps=os.makedirs) as mock:
         shutil.rmtree(ocw_downloader.destination_dir)
         ocw_downloader.download_courses()
-        mock.assert_any_call(ocw_downloader.destination_dir)
+        mock.assert_any_call(Path(ocw_downloader.destination_dir), exist_ok=True)
 
 
 @pytest.mark.parametrize("prefix,downloaded", [["PROD", True], ["QA", False]])
@@ -77,5 +77,5 @@ def test_download_courses_overwrite(ocw_downloader):
                 if folder == "0":
                     path, course = os.path.split(path)
                     for json_file in files:
-                        downloaded_path = os.path.join(path, course, "0", json_file)
+                        downloaded_path = Path(path, course, "0", json_file)
                         mock.assert_any_call(downloaded_path)

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -44,7 +44,7 @@ def load_raw_jsons(course_dir):
     for key, val in dict_of_all_course_dirs.items():
         path_to_subdir = course_dir / key
         for json_index in val:
-            file_path = path_to_subdir / f"{str(json_index) + '.json'}"
+            file_path = path_to_subdir / f"{json_index}.json"
             with open(file_path) as f:
                 loaded_json = json.load(f)
             if loaded_json:

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -3,14 +3,13 @@ from html.parser import HTMLParser
 import os
 import copy
 from pathlib import Path
-import shutil
 import base64
 from requests import get
 import boto3
-from ocw_data_parser.utils import update_file_location, get_binary_data, is_json, get_correct_path, load_json_file, \
-    find_all_values_for_key, htmlify
+from ocw_data_parser.utils import update_file_location, get_binary_data, find_all_values_for_key, htmlify
 import json
 from smart_open import smart_open
+from urllib.parse import urljoin
 
 log = logging.getLogger(__name__)
 
@@ -32,11 +31,11 @@ def load_raw_jsons(course_dir):
     for dir_in_question in course_dir.iterdir():
         if dir_in_question.is_dir():
             dict_of_all_course_dirs[dir_in_question.name] = []
-            for file in os.listdir(dir_in_question):
-                if is_json(file):
+            for file in dir_in_question.iterdir():
+                if file.suffix == ".json":
                     # Turn file name to int to enforce sequential json loading later
                     dict_of_all_course_dirs[dir_in_question.name].append(
-                        int(file.split(".")[0]))
+                        int(file.stem))
             dict_of_all_course_dirs[dir_in_question.name] = sorted(
                 dict_of_all_course_dirs[dir_in_question.name])
 
@@ -46,7 +45,8 @@ def load_raw_jsons(course_dir):
         path_to_subdir = course_dir / key
         for json_index in val:
             file_path = path_to_subdir / f"{str(json_index) + '.json'}"
-            loaded_json = load_json_file(file_path)
+            with open(file_path) as f:
+                loaded_json = json.load(f)
             if loaded_json:
                 # Add the json file name (used for error reporting)
                 loaded_json["actual_file_name"] = f"{json_index}.json"
@@ -221,10 +221,10 @@ def compose_open_learning_library_related(jsons):
     return open_learning_library_related
 
 
-class OCWParser(object):
+class OCWParser:
     def __init__(self,
-                 course_dir="",
-                 destination_dir="",
+                 course_dir=None,
+                 destination_dir=None,
                  static_prefix="",
                  loaded_jsons=None,
                  upload_to_s3=False,
@@ -240,9 +240,9 @@ class OCWParser(object):
         if loaded_jsons is None:
             loaded_jsons = []
 
-        self.course_dir = get_correct_path(
+        self.course_dir = Path(
             course_dir) if course_dir else course_dir
-        self.destination_dir = get_correct_path(
+        self.destination_dir = Path(
             destination_dir) if destination_dir else destination_dir
         self.static_prefix = static_prefix
         self.upload_to_s3 = upload_to_s3
@@ -266,7 +266,8 @@ class OCWParser(object):
             self.jsons = loaded_jsons
         if self.jsons:
             self.parsed_json = self.generate_parsed_json()
-            self.destination_dir += self.jsons[0].get("id") + "/"
+            if self.destination_dir:
+                self.destination_dir = self.destination_dir / self.jsons[0].get("id")
         self.beautify_parsed_json = beautify_parsed_json
 
     def get_parsed_json(self):
@@ -351,24 +352,27 @@ class OCWParser(object):
             log.debug("You have to compose media for course first!")
             return
 
-        path_to_containing_folder = self.destination_dir + "output/" + self.static_prefix \
-            if self.static_prefix else self.destination_dir + "output/static_files/"
-        url_path_to_media = self.static_prefix if self.static_prefix else path_to_containing_folder
+        path_to_containing_folder = (
+            self.destination_dir / "output" / self.static_prefix
+            if self.static_prefix
+            else self.destination_dir / "output" / "static_files"
+        )
+        url_path_to_media = self.static_prefix if self.static_prefix else str(path_to_containing_folder)
         os.makedirs(path_to_containing_folder, exist_ok=True)
         for page in compose_pages(self.jsons):
             filename, html = htmlify(page)
             if filename and html:
-                with open(path_to_containing_folder + filename, "w") as f:
+                with open(path_to_containing_folder / filename, "w") as f:
                     f.write(html)
         for media_json in self.media_jsons:
             file_name = media_json.get("_uid") + "_" + media_json.get("id")
             d = get_binary_data(media_json)
             if d:
-                with open(path_to_containing_folder + file_name, "wb") as f:
+                with open(path_to_containing_folder / file_name, "wb") as f:
                     data = base64.b64decode(d)
                     f.write(data)
                 update_file_location(
-                    self.parsed_json, url_path_to_media + file_name, media_json.get("_uid"))
+                    self.parsed_json, urljoin(url_path_to_media, file_name), media_json.get("_uid"))
                 log.info("Extracted %s", file_name)
             else:
                 json_file = media_json["actual_file_name"]
@@ -383,13 +387,16 @@ class OCWParser(object):
             log.debug("Your course has 0 foreign media files")
             return
 
-        path_to_containing_folder = self.destination_dir + 'output/' + self.static_prefix \
-            if self.static_prefix else self.destination_dir + "output/static_files/"
-        url_path_to_media = self.static_prefix if self.static_prefix else path_to_containing_folder
+        path_to_containing_folder = (
+            self.destination_dir / 'output' / self.static_prefix
+            if self.static_prefix else
+            self.destination_dir / "output" / "static_files"
+        )
+        url_path_to_media = self.static_prefix if self.static_prefix else str(path_to_containing_folder)
         os.makedirs(path_to_containing_folder, exist_ok=True)
         for media in self.large_media_links:
             file_name = media["link"].split("/")[-1]
-            with open(path_to_containing_folder + file_name, "wb") as file:
+            with open(path_to_containing_folder / file_name, "wb") as file:
                 response = get(media["link"])
                 file.write(response.content)
             update_file_location(
@@ -403,7 +410,7 @@ class OCWParser(object):
         if s3_links:
             self.upload_all_media_to_s3(upload_parsed_json=upload_parsed_json)
         os.makedirs(self.destination_dir, exist_ok=True)
-        file_path = os.path.join(self.destination_dir, "{}_parsed.json".format(self.parsed_json["short_url"]))
+        file_path = self.destination_dir / "{}_parsed.json".format(self.parsed_json["short_url"])
         with open(file_path, "w") as json_file:
             if self.beautify_parsed_json:
                 json.dump(self.parsed_json, json_file, sort_keys=True, indent=4)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #65 

#### What's this PR do?
Some fields like `OCWParser.course_dir` are converted to be `Path`s instead or `None` if they are empty. In general nothing should appear to have changed in the output or in the API, except for some minor changes:
 - I inlined some functions like `get_correct_path`, `is_json`, and `load_json_file`. I don't think they were used outside ocw-data-parser
 - I added an optional argument `courses_json_path` to `parse_all` so we can filter courses based on a course JSON file. If the argument is left out it should convert all directories in the input folder as it did before.

#### How should this be manually tested?
Everything should work the same as before. In particular you should be able to pass both `str` and `pathlib.Path` paths to `OCWParser` in `course_dir` and `destination_dir` and a `str` path to `OCWDownloader` for `courses_json` and `destination_dir`. 
