### PR TITLE
fix file_location bug

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -147,10 +147,10 @@ def compose_pages(jsons):
     return pages
 
 
-def _compose_media_dict(media_json, bucket_base_url, course_id):
+def _compose_media_dict(media_json, bucket_base_url):
     file_name = media_json.get("id")
     if bucket_base_url:
-        file_location = urljoin(bucket_base_url, os.path.join(course_id, file_name))
+        file_location = urljoin(bucket_base_url, file_name)
     else:
         file_location = file_name
     media_dict = {
@@ -188,7 +188,7 @@ def compose_media(jsons, bucket_base_url):
             # Keep track of the jsons that contain media in case we want to extract
             media_jsons.append(json_file)
 
-    return [_compose_media_dict(media_json, bucket_base_url, course_id) for media_json in media_jsons], media_jsons
+    return [_compose_media_dict(media_json, bucket_base_url) for media_json in media_jsons], media_jsons
 
 
 def compose_embedded_media(jsons):
@@ -457,8 +457,7 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
         course_pages = compose_pages(self.jsons)
         course_files, self.media_jsons = compose_media(
             self.jsons, 
-            self.get_s3_base_url(), 
-            self.jsons[0].get("id"))
+            self.get_s3_base_url())
         foreign_media = gather_foreign_media(self.jsons)
         self.large_media_links = foreign_media
 

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -166,7 +166,7 @@ def _compose_media_dict(media_json, bucket_base_url):
         "platform_requirements": media_json.get("other_platform_requirements"),
         "description": media_json.get("description"),
         "type": media_json.get("_type"),
-        "file_location": file_location
+        "file_location": file_location,
     }
     return media_dict
 
@@ -188,7 +188,9 @@ def compose_media(jsons, bucket_base_url):
             # Keep track of the jsons that contain media in case we want to extract
             media_jsons.append(json_file)
 
-    return [_compose_media_dict(media_json, bucket_base_url) for media_json in media_jsons], media_jsons
+    return [
+        _compose_media_dict(media_json, bucket_base_url) for media_json in media_jsons
+    ], media_jsons
 
 
 def compose_embedded_media(jsons):
@@ -456,8 +458,8 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
         instructors = self.jsons[0].get("instructors")
         course_pages = compose_pages(self.jsons)
         course_files, self.media_jsons = compose_media(
-            self.jsons, 
-            self.get_s3_base_url())
+            self.jsons, self.get_s3_base_url()
+        )
         foreign_media = gather_foreign_media(self.jsons)
         self.large_media_links = foreign_media
 

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -148,7 +148,6 @@ def compose_pages(jsons):
 
 
 def _compose_media_dict(media_json, bucket_base_url, course_id):
-    uid = media_json.get("_uid")
     file_name = media_json.get("id")
     if bucket_base_url:
         file_location = urljoin(bucket_base_url, os.path.join(course_id, file_name))
@@ -156,7 +155,7 @@ def _compose_media_dict(media_json, bucket_base_url, course_id):
         file_location = file_name
     media_dict = {
         "order_index": media_json.get("order_index"),
-        "uid": uid,
+        "uid": media_json.get("_uid"),
         "id": file_name,
         "parent_uid": media_json.get("parent_uid"),
         "title": media_json.get("title"),

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -148,15 +148,18 @@ def compose_pages(jsons):
 
 
 def _compose_media_dict(media_json, bucket_base_url):
+    uid = media_json.get("_uid")
     file_name = media_json.get("id")
+    if not file_name.startswith(uid):
+        file_name = "{}_{}".format(uid, file_name)
     if bucket_base_url:
         file_location = urljoin(bucket_base_url, file_name)
     else:
         file_location = file_name
     media_dict = {
         "order_index": media_json.get("order_index"),
-        "uid": media_json.get("_uid"),
-        "id": file_name,
+        "uid": uid,
+        "id": media_json.get("id"),
         "parent_uid": media_json.get("parent_uid"),
         "title": media_json.get("title"),
         "caption": media_json.get("caption"),

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -363,7 +363,25 @@ def test_course_files(ocw_parser):
         'file_location': '182.png'
     }
 
-
+def test_course_files_s3(ocw_parser_s3):
+    """Make sure course_files include the right fields with the correct default values"""
+    ocw_parser_s3.generate_parsed_json()
+    assert ocw_parser_s3.parsed_json['course_files'][0] == {
+        'order_index': 6,
+        'uid': 'c24518ecda658185c40c2e5eeb72c7fa',
+        'id': '182.png',
+        'parent_uid': '3f3b7835cf477d3ba10b05fbe03cbffa',
+        'title': '182.png',
+        'caption': '',
+        'file_type': 'image/png',
+        'alt_text': '',
+        'credit': '',
+        'platform_requirements': '',
+        'description': '',
+        'type': 'OCWImage',
+        'file_location': 'https://testing.s3.amazonaws.com/course-1/182.png'
+    }
+    
 def test_course_foreign_files(ocw_parser):
     """Make sure course_foreign_files include the right fields with the correct default values"""
     assert ocw_parser.parsed_json["course_foreign_files"][0] == {

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -360,7 +360,7 @@ def test_course_files(ocw_parser):
         "platform_requirements": "",
         "description": "",
         "type": "OCWImage",
-        "file_location": "182.png",
+        "file_location": "c24518ecda658185c40c2e5eeb72c7fa_182.png",
     }
 
 
@@ -380,7 +380,7 @@ def test_course_files_s3(ocw_parser_s3):
         "platform_requirements": "",
         "description": "",
         "type": "OCWImage",
-        "file_location": "https://testing.s3.amazonaws.com/course-1/182.png",
+        "file_location": "https://testing.s3.amazonaws.com/course-1/c24518ecda658185c40c2e5eeb72c7fa_182.png",
     }
 
 

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -346,20 +346,21 @@ def test_uid(ocw_parser, course_id):
 
 def test_course_files(ocw_parser):
     """Make sure course_files include the right fields with the correct default values"""
-    assert len(ocw_parser.parsed_json["course_files"]) == 172
-    assert ocw_parser.parsed_json["course_files"][0] == {
-        "order_index": 6,
-        "uid": "c24518ecda658185c40c2e5eeb72c7fa",
-        "id": "182.png",
-        "parent_uid": "3f3b7835cf477d3ba10b05fbe03cbffa",
-        "title": "182.png",
-        "caption": "",
-        "file_type": "image/png",
-        "alt_text": "",
-        "credit": "",
-        "platform_requirements": "",
-        "description": "",
-        "type": "OCWImage",
+    assert len(ocw_parser.parsed_json['course_files']) == 172
+    assert ocw_parser.parsed_json['course_files'][0] == {
+        'order_index': 6,
+        'uid': 'c24518ecda658185c40c2e5eeb72c7fa',
+        'id': '182.png',
+        'parent_uid': '3f3b7835cf477d3ba10b05fbe03cbffa',
+        'title': '182.png',
+        'caption': '',
+        'file_type': 'image/png',
+        'alt_text': '',
+        'credit': '',
+        'platform_requirements': '',
+        'description': '',
+        'type': 'OCWImage',
+        'file_location': '182.png'
     }
 
 

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -346,42 +346,44 @@ def test_uid(ocw_parser, course_id):
 
 def test_course_files(ocw_parser):
     """Make sure course_files include the right fields with the correct default values"""
-    assert len(ocw_parser.parsed_json['course_files']) == 172
-    assert ocw_parser.parsed_json['course_files'][0] == {
-        'order_index': 6,
-        'uid': 'c24518ecda658185c40c2e5eeb72c7fa',
-        'id': '182.png',
-        'parent_uid': '3f3b7835cf477d3ba10b05fbe03cbffa',
-        'title': '182.png',
-        'caption': '',
-        'file_type': 'image/png',
-        'alt_text': '',
-        'credit': '',
-        'platform_requirements': '',
-        'description': '',
-        'type': 'OCWImage',
-        'file_location': '182.png'
+    assert len(ocw_parser.parsed_json["course_files"]) == 172
+    assert ocw_parser.parsed_json["course_files"][0] == {
+        "order_index": 6,
+        "uid": "c24518ecda658185c40c2e5eeb72c7fa",
+        "id": "182.png",
+        "parent_uid": "3f3b7835cf477d3ba10b05fbe03cbffa",
+        "title": "182.png",
+        "caption": "",
+        "file_type": "image/png",
+        "alt_text": "",
+        "credit": "",
+        "platform_requirements": "",
+        "description": "",
+        "type": "OCWImage",
+        "file_location": "182.png",
     }
+
 
 def test_course_files_s3(ocw_parser_s3):
     """Make sure course_files include the right fields with the correct default values"""
     ocw_parser_s3.generate_parsed_json()
-    assert ocw_parser_s3.parsed_json['course_files'][0] == {
-        'order_index': 6,
-        'uid': 'c24518ecda658185c40c2e5eeb72c7fa',
-        'id': '182.png',
-        'parent_uid': '3f3b7835cf477d3ba10b05fbe03cbffa',
-        'title': '182.png',
-        'caption': '',
-        'file_type': 'image/png',
-        'alt_text': '',
-        'credit': '',
-        'platform_requirements': '',
-        'description': '',
-        'type': 'OCWImage',
-        'file_location': 'https://testing.s3.amazonaws.com/course-1/182.png'
+    assert ocw_parser_s3.parsed_json["course_files"][0] == {
+        "order_index": 6,
+        "uid": "c24518ecda658185c40c2e5eeb72c7fa",
+        "id": "182.png",
+        "parent_uid": "3f3b7835cf477d3ba10b05fbe03cbffa",
+        "title": "182.png",
+        "caption": "",
+        "file_type": "image/png",
+        "alt_text": "",
+        "credit": "",
+        "platform_requirements": "",
+        "description": "",
+        "type": "OCWImage",
+        "file_location": "https://testing.s3.amazonaws.com/course-1/182.png",
     }
-    
+
+
 def test_course_foreign_files(ocw_parser):
     """Make sure course_foreign_files include the right fields with the correct default values"""
     assert ocw_parser.parsed_json["course_foreign_files"][0] == {


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-data-parser/issues/103
Closes https://github.com/mitodl/hugo-course-publisher/issues/422
Closes https://github.com/mitodl/ocw-to-hugo/issues/137

#### What's this PR do?
This PR fixes a bug with regenerating parsed JSON in which in some cases the `file_location` property of items in the `course_files` array to be missing.  This change sets them to the proper S3 url if S3 uploading is set up, or simply to the filename.

#### How should this be manually tested?
Parse any of the following courses:

```
"11-943j-urban-transportation-land-use-and-the-environment-spring-2002",
"16-885j-aircraft-systems-engineering-fall-2004"
"16-891j-space-policy-seminar-spring-2003",
"18-024-multivariable-calculus-with-theory-spring-2011"
"21m-380-music-and-technology-sound-design-spring-2016",
"res-18-001-calculus-online-textbook-spring-2005"
"res-18-006-calculus-revisited-single-variable-calculus-fall-2010",
"sts-003-the-rise-of-modern-science-fall-2010"
"sts-471j-engineering-apollo-the-moon-project-as-a-complex-system-spring-2007",
```
In the parsed JSON output, ensure that every item in `course_files` has a `file_location` attribute.
