### PR TITLE
Fix media_uid_filter argument

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -704,7 +704,7 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
                     media_jsons = [
                         media_json
                         for media_json in self.media_jsons
-                        if media_json in media_uid_filter
+                        if media_json.get("_uid") in media_uid_filter
                     ]
                 else:
                     media_jsons = self.media_jsons


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #101 

#### What's this PR do?
Fixes use of `media_uid_filter` argument in `upload_course_image`. However it looks like the image was being uploaded anyway because `upload=False` is ignored since `self.upload_to_s3` is set to `True`, so this isn't fixing a bug strictly speaking. I think this is very confusing and we should fix this at some point but that's outside the scope of this PR

#### How should this be manually tested?
Nothing should break
