### PR TITLE
Check for HTTP error when downloading media, other error tweaks

### DIFF
--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -22,7 +22,7 @@ def update_file_location(parsed_json, new_file_location, obj_uid=""):
     Args:
         parsed_json (dict): The parsed JSON output to be modified with the updated file_location
         new_file_location (str): The new file_location to be set on the object
-        obj_uid
+        obj_uid (str): UID of the file to be updated
     """
     if obj_uid:
         for page in parsed_json["course_pages"]:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,3 +4,5 @@ pytest-cov
 pylint==2.6.0
 codecov
 responses==0.12.0
+pytest-mock
+


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #100 

#### What's this PR do?
We should call `.raise_for_status` for all requests made so a 404 response will cause an exception instead of an empty file.

#### How should this be manually tested?
Nothing should change in the output
