### PR TITLE
Fix release process reformatting conflict

### DIFF
--- a/ocw_data_parser/__init__.py
+++ b/ocw_data_parser/__init__.py
@@ -1,5 +1,7 @@
 """ocw-data-parser top-level exports"""
 
+__version__ = "0.18.0"
+
 from ocw_data_parser.ocw_data_parser import CustomHTMLParser, OCWParser
 from ocw_data_parser.course_downloader import OCWDownloader
 from ocw_data_parser.utils import (

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,15 @@ import sys
 
 from setuptools import setup, find_packages
 
+import ocw_data_parser
+
 if sys.version < "3.6":
     print("ERROR: python version 3 or higher is required")
     sys.exit(1)
 
 setup(
     name="ocw_data_parser",
-    version="0.18.0",
+    version=ocw_data_parser.__version__,
     packages=find_packages(),
     install_requires=["boto3>=1.9.62", "requests>=2.21.0", "smart-open>=1.8.0"],
     license="To be determined",


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes broken build. The release process alters `setup.py` to a non-formatted state by updating the version number with improper indentation. This moves the version to `__init__.py`, similar to edx-api-client, so that the indentation is not relevant anymore for updating the version.

#### How should this be manually tested?
Tests should pass
