### PR TITLE
handle course pages with text/plain content type

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -136,7 +136,10 @@ def compose_pages(jsons):
     pages = []
     for json_file in jsons:
         if (  # pylint: disable=too-many-boolean-expressions
-            json_file["_content_type"] == "text/html"
+            (
+                json_file["_content_type"] == "text/html"
+                or json_file["_content_type"] == "text/plain"
+            )
             and "technical_location" in json_file
             and json_file["technical_location"]
             and json_file["id"] != "page-not-found"

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -416,7 +416,7 @@ def test_other_version_parent_uids(ocw_parser):
 def test_course_pages(ocw_parser):
     """assert the output of composing course_pages"""
     assert len(ocw_parser.parsed_json["course_pages"]) > 0
-    page = ocw_parser.parsed_json["course_pages"][0]
+    page = ocw_parser.parsed_json["course_pages"][1]
     page_without_text = {**page}
     del page_without_text["text"]
     del page_without_text["description"]
@@ -574,7 +574,7 @@ def test_extract_media_locally(ocw_parser):
     expected_counts = {
         ".pdf": 93,
         ".srt": 36,
-        ".html": 11,
+        ".html": 12,
         ".jpg": 42,
         ".png": 1,
     }


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
This page allows processing of pages that have their content type set to `text/plain` as well as `text/html`

#### How should this be manually tested?
Parse `2-00aj-exploring-sea-space-earth-fundamentals-of-engineering-design-spring-2009` and ensure that the resulting parsed json has an entry in `course_pages` with the `type` property of `CourseHomeSection`

#### Any background context you want to provide?
https://mitodl.slack.com/archives/G01D8BCBGHY/p1608315562019200
