### PR TITLE
add SRHomePage to the types of pages that are parsed

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -125,6 +125,7 @@ def compose_pages(jsons):
     """
     page_types = [
         "CourseHomeSection",
+        "SRHomePage",
         "CourseSection",
         "DownloadSection",
         "ThisCourseAtMITSection",


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-to-hugo/issues/154

#### What's this PR do?
This PR adds `SRCourseHome` to the type of pages that are parsed so they show up in `course_pages`.

#### How should this be manually tested?
Parse any course that starts with `res-` and ensure that there is a course page of type `SRCourseHome` in the `course_pages` array.
