### PR TITLE
Handle "None" values for certain fields

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -514,7 +514,7 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
                 self.jsons[0], "last_published_to_production"
             ),
             "last_unpublishing_date": _get(self.jsons[0], "last_unpublishing_date"),
-            "retirement_date": self.jsons[0].get("retirement_date"),
+            "retirement_date": _get(self.jsons[0], "retirement_date"),
             "sort_as": self.jsons[0].get("sort_as"),
             "department_number": master_course.split(".")[0] if master_course else "",
             "master_course_number": master_course.split(".")[1]

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -22,6 +22,23 @@ from ocw_data_parser.utils import (
 log = logging.getLogger(__name__)
 
 
+def _get(obj, key):
+    """
+    Retrieve an item from a dictionary, converting "None" to None if necessary
+
+    Args:
+        obj (dict): A dict
+        key (str): A key in the dictionary
+
+    Returns:
+        any: The value at that key
+    """
+    value = obj.get(key)
+    if value == "None":
+        return None
+    return value
+
+
 class CustomHTMLParser(HTMLParser):
     """Capture links from an HTML file"""
 
@@ -490,13 +507,13 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
             "title": self.jsons[0].get("title"),
             "description": self.jsons[1].get("description"),
             "other_information_text": self.jsons[1].get("other_information_text"),
-            "first_published_to_production": self.jsons[0].get(
-                "first_published_to_production"
+            "first_published_to_production": _get(
+                self.jsons[0], "first_published_to_production"
             ),
-            "last_published_to_production": self.jsons[0].get(
-                "last_published_to_production"
+            "last_published_to_production": _get(
+                self.jsons[0], "last_published_to_production"
             ),
-            "last_unpublishing_date": self.jsons[0].get("last_unpublishing_date"),
+            "last_unpublishing_date": _get(self.jsons[0], "last_unpublishing_date"),
             "retirement_date": self.jsons[0].get("retirement_date"),
             "sort_as": self.jsons[0].get("sort_as"),
             "department_number": master_course.split(".")[0] if master_course else "",

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -5,6 +5,7 @@ import logging
 import os
 from copy import deepcopy
 from pathlib import Path
+import shutil
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
@@ -670,3 +671,32 @@ def test_publish_date(ocw_parser):
         ocw_parser.parsed_json["last_published_to_production"]
         == "2019/09/25 17:47:34.670 Universal"
     )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "first_published_to_production",
+        "last_published_to_production",
+        "last_unpublishing_date",
+    ],
+)
+def test_none(field):
+    """Assert that "None" gets converted to a null value for certain fields"""
+    with TemporaryDirectory() as destination_dir, TemporaryDirectory() as source_dir:
+        course_dir = Path(source_dir) / "course-1"
+        jsons_dir = course_dir / "0"
+        shutil.copytree(
+            "ocw_data_parser/test_json/course_dir/course-1/jsons", jsons_dir
+        )
+        with open(jsons_dir / "1.json") as file:
+            json_1 = json.load(file)
+        json_1[field] = "None"
+        with open(jsons_dir / "1.json", "w") as file:
+            json.dump(json_1, file)
+        parser = OCWParser(
+            course_dir=course_dir,
+            destination_dir=destination_dir,
+            static_prefix="static_files/",
+        )
+        assert parser.parsed_json[field] is None

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -679,6 +679,7 @@ def test_publish_date(ocw_parser):
         "first_published_to_production",
         "last_published_to_production",
         "last_unpublishing_date",
+        "retirement_date",
     ],
 )
 def test_none(field):


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Translates `"None"` to `null` for certain fields

#### How should this be manually tested?
Parse the `9-02-systems-neuroscience-laboratory-spring-2008` course and verify the `first_published_to_production` value is `null` in the output parsed JSON
