### PR TITLE
fix a typo with 'exams with solutions'

### DIFF
--- a/ocw_data_parser/course_feature_tags.py
+++ b/ocw_data_parser/course_feature_tags.py
@@ -90,7 +90,7 @@ TAG_WRITTEN_ASSIGNMENTS = "Written Assignments"
 TAG_WRITTEN_ASSIGNMENTS_WITH_EXAMPLES = "Written Assignments with Examples"
 TAG_EXAM_MATERIALS = "Exam Materials"
 TAG_EXAMS = "Exams"
-TAG_EXAMS_WITH_SOLUTION = "Exams with Solution"
+TAG_EXAMS_WITH_SOLUTIONS = "Exams with Solutions"
 TAG_IMAGE_GALLERY = "Image Gallery"
 TAG_NONE = ""
 TAG_SIMULATIONS = "Simulations"
@@ -289,7 +289,7 @@ TAG_MAPPING = [
     {
         "ocw_feature": FEATURE_EXAMS,
         "ocw_subfeature": SUBFEATURE_SOLUTIONS,
-        "course_feature_tag": TAG_EXAMS_WITH_SOLUTION,
+        "course_feature_tag": TAG_EXAMS_WITH_SOLUTIONS,
     },
     {
         "ocw_feature": FEATURE_IMAGE_GALLERY,

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -543,7 +543,7 @@ def test_course_feature_tags(ocw_parser):
             "ocw_feature_url": "./resolveuid/87609dbba9d13a6b234d62de21a20433",
         },
         {
-            "course_feature_tag": "Exams with Solution",
+            "course_feature_tag": "Exams with Solutions",
             "ocw_feature_url": "./resolveuid/c13c4766c0cf1486f0cf6435c531eaad",
         },
     ]


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
This PR fixes a small typo with the course feature tag for "exams with solutions."

#### How should this be manually tested?
Doesn't really need manual testing, but I suppose you would convert a course that matches this tag like `1-00-introduction-to-computers-and-engineering-problem-solving-fall-2005` and make sure the new tag is written in.
