### PR TITLE
add template_type to course_embedded_media

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -891,7 +891,6 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
         """
         short_url = self.parsed_json.get("short_url")
         if short_url:
-            print("uploading {}_parsed.json".format(short_url))
             s3_bucket.put_object(
                 Key=self.s3_target_folder + f"{short_url}_parsed.json",
                 Body=json.dumps(self.parsed_json),

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -253,6 +253,7 @@ def compose_embedded_media(jsons):
             temp = {
                 "order_index": json_file.get("order_index"),
                 "title": json_file["title"],
+                "template_type": json_file["template_type"],
                 "uid": json_file["_uid"],
                 "parent_uid": json_file["parent_uid"],
                 "technical_location": json_file["technical_location"],
@@ -890,6 +891,7 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
         """
         short_url = self.parsed_json.get("short_url")
         if short_url:
+            print("uploading {}_parsed.json".format(short_url))
             s3_bucket.put_object(
                 Key=self.s3_target_folder + f"{short_url}_parsed.json",
                 Body=json.dumps(self.parsed_json),

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -588,6 +588,7 @@ def test_course_embedded_media(ocw_parser):
         "technical_location": "https://ocw.mit.edu/courses/mathematics/18-06-linear-algebra-spring-2010/instructor-insights/an-interview-with-gilbert-strang-on-teaching-linear-algebra",
         "title": "An Interview with Gilbert Strang on Teaching Linear Algebra",
         "uid": "e21b71ff0fa975bfa9acb2a155aafc1d",
+        "template_type": "Embed",
     }
     assert transcript.startswith("<p><span m='6840'>SARAH HANSEN:")
     assert len(embedded_media) == 11


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-data-parser/issues/131

#### What's this PR do?
This PR adds the `template_type` property from JSON files representing embedded media to the `course_embedded_media` array in the final parsed json.  

#### How should this be manually tested?
Convert any courses with embedded video (`18-06-linear-algebra-spring-2010` is one of them) and ensure that the items in `course_embedded_media` have a `template_type` property that matches one of these:

 - `popup`
 - `thumbnail_popup`
 - `Embed`
 - `Tabbed`

#### Any background context you want to provide?
This is being added to better handle conversion of embedded videos in OCW Next related projects.
