### PR TITLE
update course features

### DIFF
--- a/ocw_data_parser/conftest.py
+++ b/ocw_data_parser/conftest.py
@@ -21,13 +21,18 @@ def s3_bucket():
     """Fake S3 bucket for testing"""
     with mock_s3():
         conn = boto3.client(
-            "s3", aws_access_key_id="testing", aws_secret_access_key="testing"
+            "s3",
+            aws_access_key_id="testing",
+            aws_secret_access_key="testing",
+            region_name="us-east-1",
         )
         conn.create_bucket(Bucket="testing")
         responses.add_passthru("https://")
         responses.add_passthru("http://")
         s3 = boto3.resource(  # pylint: disable=invalid-name
-            "s3", aws_access_key_id="testing", aws_secret_access_key="testing"
+            "s3",
+            aws_access_key_id="testing",
+            aws_secret_access_key="testing",
         )
         s3_bucket = s3.Bucket(name="testing")
         yield s3_bucket

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -297,7 +297,7 @@ def compose_course_features(jsons, course_pages):
         list of dict:
             Course feature info
     """
-    course_features = {}
+    course_features = []
     feature_requirements = jsons[0].get("feature_requirements")
     if feature_requirements:
         for feature_requirement in feature_requirements:
@@ -307,8 +307,8 @@ def compose_course_features(jsons, course_pages):
             if page:
                 course_feature = copy.copy(feature_requirement)
                 course_feature["ocw_feature_url"] = "./resolveuid/" + page["uid"]
-                course_features[page["uid"]] = course_feature
-    return list(course_features.values())
+                course_features.append(course_feature)
+    return course_features
 
 
 def compose_course_feature_tags(jsons, course_pages):
@@ -323,7 +323,7 @@ def compose_course_feature_tags(jsons, course_pages):
         list of dict:
             Course feature info
     """
-    course_feature_tags = {}
+    course_feature_tags = []
     feature_requirements = jsons[0].get("feature_requirements")
     if feature_requirements:
         for feature_requirement in feature_requirements:
@@ -336,11 +336,13 @@ def compose_course_feature_tags(jsons, course_pages):
                     feature_requirement["ocw_subfeature"],
                 )
                 if matching_tag:
-                    course_feature_tags[page["uid"]] = {
-                        "course_feature_tag": matching_tag,
-                        "ocw_feature_url": "./resolveuid/" + page["uid"],
-                    }
-    return list(course_feature_tags.values())
+                    course_feature_tags.append(
+                        {
+                            "course_feature_tag": matching_tag,
+                            "ocw_feature_url": "./resolveuid/" + page["uid"],
+                        }
+                    )
+    return course_feature_tags
 
 
 def gather_foreign_media(jsons):

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -504,6 +504,13 @@ def test_course_features(ocw_parser):
             "ocw_subfeature": "Video",
         },
         {
+            "ocw_feature": "AV recitations",
+            "ocw_feature_notes": "",
+            "ocw_feature_url": "./resolveuid/6b1f662457366951bfe85945521b0299",
+            "ocw_speciality": "",
+            "ocw_subfeature": "",
+        },
+        {
             "ocw_feature": "Assignments",
             "ocw_feature_notes": "",
             "ocw_feature_url": "./resolveuid/87609dbba9d13a6b234d62de21a20433",
@@ -536,6 +543,10 @@ def test_course_feature_tags(ocw_parser):
         },
         {
             "course_feature_tag": "Lecture Videos",
+            "ocw_feature_url": "./resolveuid/6b1f662457366951bfe85945521b0299",
+        },
+        {
+            "course_feature_tag": "Recitation Videos",
             "ocw_feature_url": "./resolveuid/6b1f662457366951bfe85945521b0299",
         },
         {

--- a/ocw_data_parser/test_json/course_dir/course-1/jsons/1.json
+++ b/ocw_data_parser/test_json/course_dir/course-1/jsons/1.json
@@ -4206,6 +4206,13 @@
             "ocw_subfeature": "Video"
         },
         {
+            "ocw_feature": "AV recitations",
+            "ocw_feature_notes": "",
+            "ocw_feature_url": "/courses/mathematics/18-06-linear-algebra-spring-2010/video-lectures",
+            "ocw_speciality": "",
+            "ocw_subfeature": ""
+        },
+        {
             "ocw_feature": "Assignments",
             "ocw_feature_notes": "",
             "ocw_feature_url": "/courses/mathematics/18-06-linear-algebra-spring-2010/assignments",


### PR DESCRIPTION
#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3369

#### What's this PR do?
This pr updates the parser to include the same page multiple times in `course_features` and `course_feature_tags` in the parsed json when multiple features point to the same ocw page.

#### How should this be manually tested?
Download the raw data for `/PROD/5/5.08J/Spring_2016/5-08j-biological-chemistry-ii-spring-2016`
Parse the data locally
You should see both `Lecture Videos` and `Recitation Videos` in the `course_feature_tags` of the parsed json
You should see both `AV lectures` and `AV recitations` in `course_features`

