### PR TITLE
parse aka_course_number into new_course_numbers

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -549,7 +549,7 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
             else "",
             "new_course_numbers": [
                 {
-                    key.replace("aka_", ""): value
+                    key.replace("aka_", "") if key.startswith("aka_") else key: value
                     for key, value in aka_course_number.items()
                 }
                 for aka_course_number in aka_course_numbers

--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -518,6 +518,7 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
                 self.course_thumbnail_image_uid = j.get("chp_image_thumb")
 
         master_course = self.jsons[0].get("master_course_number")
+        aka_course_numbers = self.jsons[0].get("aka_course_number")
         technical_location = self.jsons[0].get("technical_location")
         instructors = self.jsons[0].get("instructors")
         course_pages = compose_pages(self.jsons)
@@ -546,6 +547,15 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
             "master_course_number": master_course.split(".")[1]
             if master_course
             else "",
+            "new_course_numbers": [
+                {
+                    key.replace("aka_", ""): value
+                    for key, value in aka_course_number.items()
+                }
+                for aka_course_number in aka_course_numbers
+            ]
+            if aka_course_numbers
+            else [],
             "other_version_parent_uids": self.jsons[0].get("master_subject"),
             "from_semester": self.jsons[0].get("from_semester"),
             "from_year": self.jsons[0].get("from_year"),

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -418,6 +418,16 @@ def test_other_version_parent_uids(ocw_parser):
     assert len(ocw_parser.parsed_json["other_version_parent_uids"]) == 1
 
 
+def test_aka_course_number(ocw_parser):
+    """Make sure the aka_course_number field is transformed property into new_course_numbers"""
+    assert ocw_parser.parsed_json["new_course_numbers"][0] == {
+        "new_course_number_col": "18.06TEST",
+        "old_course_number_col": "18.06",
+        "sort_as_col": "18.06TEST",
+        "course_type_col": "Undergraduate",
+    }
+
+
 def test_course_pages(ocw_parser):
     """assert the output of composing course_pages"""
     assert len(ocw_parser.parsed_json["course_pages"]) > 0

--- a/ocw_data_parser/test_json/course_dir/course-1/jsons/1.json
+++ b/ocw_data_parser/test_json/course_dir/course-1/jsons/1.json
@@ -4112,7 +4112,14 @@
         ]
     },
     "aggregationlevel": 4,
-    "aka_course_number": [],
+    "aka_course_number": [
+        {
+            "aka_new_course_number_col": "18.06TEST", 
+            "aka_old_course_number_col": "18.06", 
+            "aka_sort_as_col": "18.06TEST", 
+            "aka_course_type_col": "Undergraduate"
+        }
+    ],
     "allowDiscussion": false,
     "always_publish": false,
     "category_features": [


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-data-parser/issues/137

#### What's this PR do?
OCW Plone JSON exports include a field in the first file called `aka_course_number`, which is actually an array of objects.  The objects contain an old course number and information pertaining to the new course number including, the level (graduate / undergraduate) and a "sort by column."  This PR parses this field and renames the key to `new_course_numbers`.  The `aka_` prefix is removed from the keys in the object.  Since these objects serve as "updates" to the course number, it makes more sense to call it "new" and use "numbers" because there can be multiple updates.  To find the latest one, you would follow the chain starting at the course number listed directly on the course, finding the item in `new_course_numbers` where `old_course_number` matches that number and so on.

#### How should this be manually tested?
 - Convert a course with a populated `aka_course_number` field like `18-443-statistics-for-applications-spring-2015`
 - Verify that the `new_course_numbers` field looks right and makes sense
