### PR TITLE
Add fields related to handling archived courses

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -528,6 +528,8 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
         foreign_media = gather_foreign_media(self.jsons)
         self.large_media_links = foreign_media
 
+        is_update_of_list = self.jsons[0].get("is_update_of", [])
+        is_update_of = is_update_of_list[0] if is_update_of_list else None
         # Generate parsed JSON
         new_json = {
             "uid": self.jsons[0].get("_uid"),
@@ -593,6 +595,9 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
             "open_learning_library_related": compose_open_learning_library_related(
                 self.jsons
             ),
+            "dspace_handle": self.jsons[0].get("dspace_handle"),
+            "features_tracking": self.jsons[0].get("features_tracking"),
+            "is_update_of": is_update_of,
         }
 
         self.parsed_json = new_json

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -745,3 +745,39 @@ def test_none(field):
             static_prefix="static_files/",
         )
         assert parser.parsed_json[field] is None
+
+
+def test_archived_course_fields(ocw_parser):
+    """Assert that fields related to handling archived courses are passed through more or less"""
+    assert ocw_parser.parsed_json["dspace_handle"] == ""
+    assert ocw_parser.parsed_json["is_update_of"] == "389a811a12a85b2225f41dca56699e0c"
+    assert ocw_parser.parsed_json["features_tracking"] == [
+        {
+            "ocw_feature": "Translations",
+            "ocw_feature_notes": "",
+            "ocw_feature_url": "http://www.core.org.cn/OcwWeb/Mathematics/18-06Linear-AlgebraFall2002/CourseHome/index.htm",
+            "ocw_speciality": "",
+            "ocw_subfeature": "Chinese (Simplified)",
+        },
+        {
+            "ocw_feature": "Translations",
+            "ocw_feature_notes": "",
+            "ocw_feature_url": "http://www.acikders.org.tr/course/view.php?id=32",
+            "ocw_speciality": "",
+            "ocw_subfeature": "Turkish",
+        },
+        {
+            "ocw_feature": "Previous version",
+            "ocw_feature_notes": "",
+            "ocw_feature_url": "http://hdl.handle.net/1721.1/59010",
+            "ocw_speciality": "",
+            "ocw_subfeature": "",
+        },
+        {
+            "ocw_feature": "Captions/Transcript",
+            "ocw_feature_notes": "",
+            "ocw_feature_url": "/courses/mathematics/18-06-linear-algebra-spring-2010/video-lectures",
+            "ocw_speciality": "",
+            "ocw_subfeature": "",
+        },
+    ]


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #141 

#### What's this PR do?
Passes through a few fields related to handling archived courses so that we can create other versions text in ocw-to-hugo

#### How should this be manually tested?
Run ocw-data-parser on `18-01-single-variable-calculus-fall-2003` and verify that `dspace_handle`, `features_tracking`, and `is_update_of` exist in the parsed JSON.
