### PR TITLE
Pass through is_update_of

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -528,8 +528,6 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
         foreign_media = gather_foreign_media(self.jsons)
         self.large_media_links = foreign_media
 
-        is_update_of_list = self.jsons[0].get("is_update_of", [])
-        is_update_of = is_update_of_list[0] if is_update_of_list else None
         # Generate parsed JSON
         new_json = {
             "uid": self.jsons[0].get("_uid"),
@@ -597,7 +595,7 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
             ),
             "dspace_handle": self.jsons[0].get("dspace_handle"),
             "features_tracking": self.jsons[0].get("features_tracking"),
-            "is_update_of": is_update_of,
+            "is_update_of": self.jsons[0].get("is_update_of"),
         }
 
         self.parsed_json = new_json

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -750,7 +750,9 @@ def test_none(field):
 def test_archived_course_fields(ocw_parser):
     """Assert that fields related to handling archived courses are passed through more or less"""
     assert ocw_parser.parsed_json["dspace_handle"] == ""
-    assert ocw_parser.parsed_json["is_update_of"] == "389a811a12a85b2225f41dca56699e0c"
+    assert ocw_parser.parsed_json["is_update_of"] == [
+        "389a811a12a85b2225f41dca56699e0c"
+    ]
     assert ocw_parser.parsed_json["features_tracking"] == [
         {
             "ocw_feature": "Translations",


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #141 

#### What's this PR do?
Passes through `is_update_of` instead of taking the first element. I assumed incorrectly that all courses had one item for this field, but I ran a script to count and a small number of courses have multiple items for this field:

    21h-009-the-world-1400-present-spring-2014 2
    7-013-introductory-biology-spring-2018 2
    cms-608-game-design-spring-2014 2
    21w-747-rhetoric-spring-2015 4
    6-033-computer-system-engineering-spring-2018 2
    6-011-signals-systems-and-inference-spring-2018 2
    6-803-the-human-intelligence-enterprise-spring-2019 2
    8-04-quantum-physics-i-spring-2013 2
    8-09-classical-mechanics-iii-fall-2014 2
    8-05-quantum-physics-ii-fall-2013 2
    15-810-marketing-management-fall-2010 3
    15-810-marketing-management-fall-2004 3
    18-650-statistics-for-applications-fall-2016 3
    18-335j-introduction-to-numerical-methods-spring-2019 2
    21g-103-chinese-iii-regular-fall-2018 2
    21g-107-chinese-i-streamlined-fall-2014 2
    21g-104-chinese-iv-regular-spring-2018 2


#### How should this be manually tested?
If you parse `15-810-marketing-management-fall-2010` you should see that the output parsed JSON contains a list of multiple items for `is_update_of` 

