### PR TITLE
Handle unexpected errors when converting VTT files

### DIFF
--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -322,6 +322,11 @@ def convert_to_vtt(loaded_json):
                         msg,
                     )
                     return None
+                except:  # pylint: disable=bare-except
+                    log.exception(
+                        "Unknown error when converting vtt %s", loaded_json["id"]
+                    )
+                    return None
             with open(Path(temp_dir) / "data.vtt", "rb") as file:
                 data = file.read()
             new_json["_datafield_file"] = {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #151 

#### What's this PR do?
Adds a blank try except clause to catch and log any unexpected errors while converting VTT files

#### How should this be manually tested?
If you run `parse_all` on the whole raw courses folder, or just the `PROD/physics` directory, you should be able to reproduce the error from #151. The error should print out but otherwise be ignored.

