### PR TITLE
Generate a UUID for vtt files

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -405,10 +405,17 @@ def compose_open_learning_library_related(jsons):
                 courses_and_links = raw_url.split(",")
                 for course_and_link in courses_and_links:
                     related_course = {}
-                    course, url = course_and_link.strip().split("::")
-                    related_course["course"] = course
-                    related_course["url"] = url
-                    open_learning_library_related.append(related_course)
+                    try:
+                        course, url = course_and_link.strip().split("::")
+                        related_course["course"] = course
+                        related_course["url"] = url
+                        open_learning_library_related.append(related_course)
+                    except:  # pylint: disable=bare-except
+                        log.exception(
+                            "Unable to parse ocw_feature_url %s for course %s",
+                            raw_url,
+                            jsons[0].get("short_url"),
+                        )
     return open_learning_library_related
 
 

--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -4,6 +4,7 @@ import tempfile
 from base64 import b64decode, b64encode
 from pathlib import Path
 from datetime import datetime
+import uuid
 
 import os
 import shutil
@@ -306,7 +307,7 @@ def convert_to_vtt(loaded_json):
     new_json["technical_location"] = update_srt_to_vtt(
         loaded_json["technical_location"]
     )
-    new_json["_uid"] = f"vtt{loaded_json['_uid']}"
+    new_json["_uid"] = uuid.uuid5(uuid.UUID(loaded_json["_uid"]), "vtt").hex
     binary_data = get_binary_data(loaded_json)
     if binary_data is not None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #157 
Fixes #156 

#### What's this PR do?
Generates UUIDs for `vtt` files which we create based on existing `srt` files. We previously added a `vtt` prefix to the `srt` uid, but that doesn't interact well when we work with UUIDs in ocw-studio. This uses [uuid5](https://docs.python.org/3/library/uuid.html#uuid.uuid5) which creates a UUID based off of another UUID, so we can generate the same UUID each time we run ocw-data-parser.

I also made a fix for #156 to more gracefully handle bad data when parsing `ocw_feature_url`

#### How should this be manually tested?
- Run `parse_all("./raw_courses", "./parsed_courses", upload_parsed_json=False, overwrite=True, create_vtt_files=True, beautify_parsed_json=True, s3_bucket="open-learning-course-data-ci", s3_links=True)` on a collection of raw courses 3 times: once for master, and two other times for this PR
- Compare the two PR directories and you should see no changes at all. This should make sure that we aren't using a random value for generating the UUID.
- Compare one of the PR directories with master. You should see only some changes here and there, where a UUID on master starting with `vtt` is now a proper UUID that looks different.

