### PR TITLE
Add 'text/plain' resources

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -226,7 +226,9 @@ def compose_media(jsons, bucket_base_url):
     media_jsons = []
     all_media_types = find_all_values_for_key(jsons, "_content_type")
     for json_file in jsons:
-        if json_file["_content_type"] in all_media_types:
+        if json_file["_content_type"] in all_media_types and json_file.get(
+            "_type", ""
+        ).startswith("OCW"):
             # Keep track of the jsons that contain media in case we want to extract
             media_jsons.append(json_file)
 

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -393,7 +393,7 @@ def test_course_files(ocw_parser):
 
 
 def test_course_files_kml_included(ocw_parser_course_2):
-    """Make sure course_files include the right fields with the correct default values"""
+    """Make sure a text/plain KML file is included in course_files"""
     assert len(ocw_parser_course_2.parsed_json["course_files"]) == 87
     assert ocw_parser_course_2.parsed_json["course_files"][84] == {
         "order_index": 98,

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -392,6 +392,26 @@ def test_course_files(ocw_parser):
     }
 
 
+def test_course_files_kml_included(ocw_parser_course_2):
+    """Make sure course_files include the right fields with the correct default values"""
+    assert len(ocw_parser_course_2.parsed_json["course_files"]) == 87
+    assert ocw_parser_course_2.parsed_json["course_files"][84] == {
+        "order_index": 98,
+        "uid": "97f28b51c2d76bbffa1213260d56c281",
+        "id": "12.001_Field_TripStops2014.kml",
+        "parent_uid": "de36fe69cf33ddf238bc3896d0ce9eff",
+        "title": "12.001_Field_TripStops2014.kml",
+        "caption": None,
+        "file_type": "text/xml",
+        "alt_text": None,
+        "credit": None,
+        "platform_requirements": "Keyhole Markup Language (KML) is an XML-based language schema for expressing geographic annotation and visualization on existing or future Web-based, two-dimensional maps and three-dimensional Earth browsers.",
+        "description": "This is the special resource regarding field trip stops.",
+        "type": "OCWFile",
+        "file_location": "97f28b51c2d76bbffa1213260d56c281_12.001_Field_TripStops2014.kml",
+    }
+
+
 def test_course_files_s3(ocw_parser_s3):
     """Make sure course_files include the right fields with the correct default values"""
     ocw_parser_s3.generate_parsed_json()

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -716,6 +716,29 @@ def test_extract_media_locally(ocw_parser):
     assert counts == expected_counts
 
 
+def test_extract_text_media_locally(ocw_parser_course_2):
+    """extract_media_locally should write plain/text media files to a local directory"""
+    ocw_parser_course_2.extract_media_locally()
+    static_files = Path(ocw_parser_course_2.destination_dir) / "output" / "static_files"
+    for path in static_files.iterdir():
+        assert path.stat().st_size > 0  # make sure files are non-trivial
+
+    expected_counts = {
+        ".pdf": 60,
+        ".html": 12,
+        ".jpg": 25,
+        ".png": 1,
+        ".kml": 1,
+    }
+    counts = {}
+    for path in static_files.iterdir():
+        ext = os.path.splitext(path)[1]
+        if ext not in counts:
+            counts[ext] = 0
+        counts[ext] += 1
+    assert counts == expected_counts
+
+
 def test_populate_vtt_files(ocw_parser):
     """populate_vtt_files should duplicate srt content files"""
     subrip_count = 0

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -402,7 +402,7 @@ def test_course_files_kml_included(ocw_parser_course_2):
         "parent_uid": "de36fe69cf33ddf238bc3896d0ce9eff",
         "title": "12.001_Field_TripStops2014.kml",
         "caption": None,
-        "file_type": "text/xml",
+        "file_type": "text/plain",
         "alt_text": None,
         "credit": None,
         "platform_requirements": "Keyhole Markup Language (KML) is an XML-based language schema for expressing geographic annotation and visualization on existing or future Web-based, two-dimensional maps and three-dimensional Earth browsers.",

--- a/ocw_data_parser/test_json/course_dir/course-2/jsons/98.json
+++ b/ocw_data_parser/test_json/course_dir/course-2/jsons/98.json
@@ -15,7 +15,7 @@
         ]
     },
     "_classname": "OCWFile",
-    "_content_type": "text/xml",
+    "_content_type": "text/plain",
     "_content_type_course_identifier": "text/plain",
     "_content_type_description": "text/plain",
     "_content_type_id": "text/plain",

--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -123,7 +123,7 @@ def find_all_values_for_key(jsons, key="_content_type"):
     Returns:
         list of str: A list of content types
     """
-    excluded_values = ["text/plain", "text/html"]
+    excluded_values = ["text/html"]
     result = set()
     for j in jsons:
         if key in j and j[key]:


### PR DESCRIPTION
#### What are the relevant tickets?
Fix for #169 

#### What's this PR do?
No longer excludes files of type `text/plain` from being included as resources

#### How should this be manually tested?
Modify/create a `course.json` file to include `2-007-design-and-manufacturing-i-spring-2009`
```python
from ocw_parser import *
downloader = OCWDownloader(
    "course.json", "PROD", "private/raw_courses", "ocw-content-storage"
)
downloader.download_courses()
parser = OCWParser(
    "private/raw_courses/PROD/2/2.007/Spring_2009/2-007-design-and-manufacturing-i-spring-2009/",
    "private/output",
)
parser.extract_media_locally()
```

Check that there are 3 dxf files at `private/output/2-007-design-and-manufacturing-i-spring-2009/output/static_files`.
