### PR TITLE
Persisted chp_display_level in parsed json

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -554,6 +554,7 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
             "title": self.jsons[0].get("title"),
             "description": self.jsons[1].get("description"),
             "other_information_text": self.jsons[1].get("other_information_text"),
+            "chp_display_level": self.jsons[0].get("chp_display_level"),
             "first_published_to_production": _get(
                 self.jsons[0], "first_published_to_production"
             ),


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #174 

#### What's this PR do?
Adds chp_display_level to parsed json

#### How should this be manually tested?
Parse relevant courses and verify.
- chp_display_level is persisted in parsed json
