### PR TITLE
fix: start, end time persisted

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -270,6 +270,8 @@ def compose_embedded_media(jsons):
                 "related_resources_text": json_file["related_resources_text"],
                 "transcript": json_file["transcript"],
                 "embedded_media": [],
+                "start_time": json_file["start_time"],
+                "end_time": json_file["end_time"],
             }
             # Find all children of linked embedded media
             for child in jsons:

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -663,6 +663,8 @@ def test_course_embedded_media(ocw_parser):
         "title": "An Interview with Gilbert Strang on Teaching Linear Algebra",
         "uid": "e21b71ff0fa975bfa9acb2a155aafc1d",
         "template_type": "Embed",
+        "start_time": "",
+        "end_time": "",
     }
     assert transcript.startswith("<p><span m='6840'>SARAH HANSEN:")
     assert len(embedded_media) == 11


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-data-parser/issues/181

#### What's this PR do?
Adds start and end time for media resources

#### How should this be manually tested?
- Parse courses that have videos ("media_resource_type": "Video",  "_type": "MediaResource" etc)
- Verify that the parsed json contains start and end time for video resources.

