### PR TITLE
feat: persist media_index data on video resources

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -272,6 +272,7 @@ def compose_embedded_media(jsons):
                 "embedded_media": [],
                 "start_time": json_file["start_time"],
                 "end_time": json_file["end_time"],
+                "media_index": json_file["media_index"],
             }
             # Find all children of linked embedded media
             for child in jsons:

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -93,7 +93,7 @@ def test_load_raw_jsons_invalid_file(ocw_parser):
 
 
 def test_load_raw_jsons():
-    """Test that load_raw_jsons """
+    """Test that load_raw_jsons"""
     with TemporaryDirectory() as project_dir:
         for num in range(1, 4000):
             group = int(num / 1000)
@@ -359,7 +359,7 @@ def test_uid(ocw_parser, course_id):
 
 
 def test_highlight_text(ocw_parser, ocw_parser_course_2):
-    """ Test that highlight_text makes it into parsed json with correct values"""
+    """Test that highlight_text makes it into parsed json with correct values"""
     assert ocw_parser.parsed_json["highlights_text"].startswith(
         "<p>This course parallels"
     )
@@ -367,7 +367,7 @@ def test_highlight_text(ocw_parser, ocw_parser_course_2):
 
 
 def test_related_content(ocw_parser, ocw_parser_course_2):
-    """ Test that related_content makes it into parsed json with correct values"""
+    """Test that related_content makes it into parsed json with correct values"""
     assert ocw_parser.parsed_json["related_content"] == "some related content"
     assert ocw_parser_course_2.parsed_json["related_content"] == ""
 

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -665,6 +665,7 @@ def test_course_embedded_media(ocw_parser):
         "template_type": "Embed",
         "start_time": "",
         "end_time": "",
+        "media_index": [],
     }
     assert transcript.startswith("<p><span m='6840'>SARAH HANSEN:")
     assert len(embedded_media) == 11

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-black==20.8b1
+black==22.3.0
 moto
 pytest-cov
 pylint==2.6.0


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-data-parser/issues/184

#### What's this PR do?
- Persists `media_index` by adding it in `compose_embedded_media`

#### How should this be manually tested?
- Parse courses locally and verify that video resources have `media_index`

#### Any background context you want to provide?
- Start and end time were also persisted for video resources in this [PR](https://github.com/mitodl/ocw-data-parser/pull/182)
followed by a few other things.