### PR TITLE
feat: persist excludeFromNav

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -623,6 +623,7 @@ class OCWParser:  # pylint: disable=too-many-instance-attributes
             "is_update_of": self.jsons[0].get("is_update_of"),
             "highlights_text": self.jsons[1].get("highlights_text"),
             "related_content": self.jsons[1].get("related_content"),
+            "excludeFromNav": self.jsons[1].get("excludeFromNav"),
         }
 
         self.parsed_json = new_json

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -372,6 +372,12 @@ def test_related_content(ocw_parser, ocw_parser_course_2):
     assert ocw_parser_course_2.parsed_json["related_content"] == ""
 
 
+def test_exclude_from_nav(ocw_parser, ocw_parser_course_2):
+    """Test that excludeFromNav makes it into parsed json with correct values"""
+    assert ocw_parser.parsed_json["excludeFromNav"] == False
+    assert ocw_parser_course_2.parsed_json["excludeFromNav"] == False
+
+
 def test_course_files(ocw_parser):
     """Make sure course_files include the right fields with the correct default values"""
     assert len(ocw_parser.parsed_json["course_files"]) == 172

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -374,8 +374,8 @@ def test_related_content(ocw_parser, ocw_parser_course_2):
 
 def test_exclude_from_nav(ocw_parser, ocw_parser_course_2):
     """Test that excludeFromNav makes it into parsed json with correct values"""
-    assert ocw_parser.parsed_json["excludeFromNav"] == False
-    assert ocw_parser_course_2.parsed_json["excludeFromNav"] == False
+    assert ocw_parser.parsed_json["excludeFromNav"] is False
+    assert ocw_parser_course_2.parsed_json["excludeFromNav"] is False
 
 
 def test_course_files(ocw_parser):


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-data-parser/issues/166

#### What's this PR do?
- Persists `excludeFromNav`

#### How should this be manually tested?
- Parse courses locally and verify that `excludeFromNav` is there in the parsed JSON
