### PR TITLE
add text field to embedded media

### DIFF
--- a/ocw_data_parser/ocw_data_parser.py
+++ b/ocw_data_parser/ocw_data_parser.py
@@ -268,6 +268,7 @@ def compose_embedded_media(jsons):
                 "optional_tab_title": json_file.get("optional_tab_title"),
                 "resource_index_text": json_file.get("resource_index_text"),
                 "related_resources_text": json_file["related_resources_text"],
+                "text": json_file["text"],
                 "transcript": json_file["transcript"],
                 "embedded_media": [],
                 "start_time": json_file["start_time"],

--- a/ocw_data_parser/ocw_data_parser_test.py
+++ b/ocw_data_parser/ocw_data_parser_test.py
@@ -669,6 +669,7 @@ def test_course_embedded_media(ocw_parser):
         "title": "An Interview with Gilbert Strang on Teaching Linear Algebra",
         "uid": "e21b71ff0fa975bfa9acb2a155aafc1d",
         "template_type": "Embed",
+        "text": "",
         "start_time": "",
         "end_time": "",
         "media_index": [],


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-data-parser/issues/190

#### What's this PR do?
`ocw-data-parser` handles "embedded media" objects separately from pages.  `compose_embedded_media` pulls in a number of properties, but does not pull in `text`.  Some videos in the legacy system have their description set on the `text` property as HTML.  This PR pulls in this property along with the other embedded resource metadata.

#### How should this be manually tested?
 - If you haven't ever used `ocw-data-parser` before, make sure you configure a virtualenv and install the requirements in `text_requirements.txt`
 - Make sure you have the AWS CLI installed locally and configure your access keys to be the same as Open Discussions production
 - Place the following in `private/courses.json`:
```
{
  "courses": [
      "16-346-astrodynamics-fall-2008"
  ]
}
```
 - Activate your virtualenv and drop into a python shell
 - Run the following:
```
from ocw_data_parser import *
downloader = OCWDownloader("private/courses.json", "PROD", "private/input", "ocw-content-storage")
downloader.download_courses()
parse_all(courses_dir="private/input", destination_dir="private/output", upload_parsed_json=False, s3_bucket="open-learning-course-data-production", s3_links=True, beautify_parsed_json=True, overwrite=True, create_vtt_files=True)
 ```
 - Open the parsed JSON file at `private/output/16-346-astrodynamics-fall-2008/16-346-astrodynamics-fall-2008_parsed.json`
 - Verify that you see the following text:
```
            "text": "<p>In the spring of 1961, President Kennedy announced that America would send astronauts to the moon and return them safely to earth. Exactly eleven weeks later MIT was chosen by NASA as the first prime contractor to supply the Guidance and Navigation System for the Apollo spacecrafts.  Professor Battin was involved in this project, and gave the following lecture during MIT&rsquo;s January term.</p> <h2 class=\"subhead\">Some Funny Things Happened on the Way to the Moon: A History of MIT's Participation in the Guidance, Navigation and Control of the Apollo Spacecraft</h2>",
```
