### PR TITLE
When downloading resource links, replace ocw.mit.edu with old.ocw.mit.edu

### DIFF
--- a/ocw_data_parser/utils.py
+++ b/ocw_data_parser/utils.py
@@ -96,6 +96,7 @@ def get_binary_data(json_obj):
         url = json_obj["technical_location"]
 
     if url:
+        url = url.replace("://ocw.mit.edu/", "://old.ocw.mit.edu/")
         resp = requests.get(url)
         if resp.ok:
             return resp.content

--- a/ocw_data_parser/utils_test.py
+++ b/ocw_data_parser/utils_test.py
@@ -66,6 +66,11 @@ def test_update_foreign_file_location(ocw_parser):
     "url, expected_url",
     [
         ["http://ocw.mit.edu/a/url", "http://old.ocw.mit.edu/a/url"],
+        ["https://ocw.mit.edu/a/url", "https://old.ocw.mit.edu/a/url"],
+        [
+            "https://ocw.mit.edu/ocw.mit.edu/url",
+            "https://old.ocw.mit.edu/ocw.mit.edu/url",
+        ],
         ["http://other.mit.edu/a/url", "http://other.mit.edu/a/url"],
     ],
 )

--- a/ocw_data_parser/utils_test.py
+++ b/ocw_data_parser/utils_test.py
@@ -62,11 +62,16 @@ def test_update_foreign_file_location(ocw_parser):
 @pytest.mark.parametrize("base64_key", ["_datafield_image", "_datafield_file", None])
 @pytest.mark.parametrize("url_key", ["unique_identifier", "technical_location", None])
 @pytest.mark.parametrize("is_valid_request", [True, False])
-@pytest.mark.parametrize("url, expected_url", [
-    ["http://ocw.mit.edu/a/url", "http://old.ocw.mit.edu/a/url"],
-    ["http://other.mit.edu/a/url", "http://other.mit.edu/a/url"],
-])
-def test_get_binary_data(mocker, ocw_parser, base64_key, url_key, is_valid_request, url, expected_url):
+@pytest.mark.parametrize(
+    "url, expected_url",
+    [
+        ["http://ocw.mit.edu/a/url", "http://old.ocw.mit.edu/a/url"],
+        ["http://other.mit.edu/a/url", "http://other.mit.edu/a/url"],
+    ],
+)
+def test_get_binary_data(
+    mocker, ocw_parser, base64_key, url_key, is_valid_request, url, expected_url
+):  # pylint:disable=too-many-arguments
     """
     get_binary_data should look up base64 encoded values from certain addresses
     """

--- a/ocw_data_parser/utils_test.py
+++ b/ocw_data_parser/utils_test.py
@@ -62,12 +62,15 @@ def test_update_foreign_file_location(ocw_parser):
 @pytest.mark.parametrize("base64_key", ["_datafield_image", "_datafield_file", None])
 @pytest.mark.parametrize("url_key", ["unique_identifier", "technical_location", None])
 @pytest.mark.parametrize("is_valid_request", [True, False])
-def test_get_binary_data(mocker, ocw_parser, base64_key, url_key, is_valid_request):
+@pytest.mark.parametrize("url, expected_url", [
+    ["http://ocw.mit.edu/a/url", "http://old.ocw.mit.edu/a/url"],
+    ["http://other.mit.edu/a/url", "http://other.mit.edu/a/url"],
+])
+def test_get_binary_data(mocker, ocw_parser, base64_key, url_key, is_valid_request, url, expected_url):
     """
     get_binary_data should look up base64 encoded values from certain addresses
     """
     data = b"abcde"
-    url = "http://example.mit.edu/a/url"
     get_mock = mocker.patch("requests.get")
     get_mock.return_value.ok = is_valid_request
     get_mock.return_value.content = data
@@ -91,7 +94,7 @@ def test_get_binary_data(mocker, ocw_parser, base64_key, url_key, is_valid_reque
     assert expected == out_data
 
     if url_key is not None and base64_key is None:
-        get_mock.assert_called_once_with(url)
+        get_mock.assert_called_once_with(expected_url)
 
 
 def test_get_binary_data_url(ocw_parser):


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #194 

#### What's this PR do?
Replaces `ocw.mit.edu` with `old.ocw.mit.edu` in resource urls when downloading them.

#### How should this be manually tested?
- Put this in a `course.json` file:
  ```
  {
    "courses": [
        "3-016-mathematics-for-materials-scientists-and-engineers-fall-2005"
    ]
  }
  ```
- Set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment values to the same as on RC, and run the following:
  ```
  from ocw_data_parser import OCWParser, OCWDownloader
  
  downloader = OCWDownloader(
    "course.json", "PROD", "private/raw_courses", "ocw-content-storage"
  )
  downloader.download_courses()
  
  parser = OCWParser(
     "private/raw_courses/PROD/3/3.016/Fall_2005/3-016-mathematics-for-materials-scientists-and-engineers-fall-2005/",
     "private/output",
  )
  parser.extract_media_locally()
  ```
  Look in the `output/3-016-mathematics-for-materials-scientists-and-engineers-fall-2005/output/static_files` for files `d43d16aa2aa00e5ac170ac148986d1e0_Lecture18.zip` and `638f9ae65a92ce94e59ed54811c2779a_Lecture11.zip`, they should be working, extractable zip files.
  